### PR TITLE
Add initial code

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+      "jetbrains.resharper.globaltools": {
+          "version": "2021.3.1",
+          "commands": [
+              "jb"
+          ]
+      }
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,0 @@
-root = true
-
-[*]
-end_of_line = lf
-charset = utf-8
-insert_final_newline = true
-indent_style = space
-indent_size = 4
-trim_trailing_whitespace = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,174 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_NOLOGO: true
+  dotnet_3_version: '3.1.415'
+  dotnet_5_version: '5.0.403'
+
+jobs:
+
+  check-format:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
+    name: Check format
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ env.dotnet_5_version }}
+      - name: Code formating check
+        run: |
+          dotnet tool restore
+          dotnet jb cleanupcode --profile="Built-in: Reformat Code" --settings="ParquetSharp.DataFrame.DotSettings" --dotnetcoresdk=${{ env.dotnet_5_version }} --verbosity=WARN "ParquetSharp.DataFrame" "ParquetSharp.DataFrame.Test"
+
+          files=($(git diff --name-only))
+          if [ ${#files[@]} -gt 0 ]
+          then
+            for file in $files; do echo "::error file=$file::Code format check failed"; done
+            exit 1
+          fi
+
+  # Build the nuget package and upload it as an artifact.
+  build-nuget:
+    name: Build NuGet package
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.dotnet_5_version }}
+    - name: Pin .NET Core SDK
+      run: dotnet new globaljson --sdk-version ${{ env.dotnet_5_version }}
+    - name: Build project
+      run: dotnet build ParquetSharp.DataFrame --configuration=Release
+    - name: Build NuGet package
+      run: dotnet pack ParquetSharp.DataFrame --configuration=Release --no-build --output nuget
+    - name: Upload NuGet artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: nuget-package
+        path: nuget
+
+  # Run .NET unit tests with the nuget package on all platforms and all supported .NET runtimes (thus testing the user workflow).
+  test-nuget:
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
+        dotnet: [3, 5]
+        arch: [x64]
+        include:
+        - os: windows-latest
+          dotnet: 4
+          arch: x64
+      fail-fast: false
+    name: Test NuGet package (.NET ${{ matrix.dotnet }} ${{ matrix.arch }} on ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: build-nuget
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Get version
+      id: get-version
+      run: echo "::set-output name=version::$((Select-Xml -Path ./ParquetSharp.DataFrame/ParquetSharp.DataFrame.csproj -XPath '/Project/PropertyGroup/Version/text()').node.Value)"
+      shell: pwsh
+    - name: Download NuGet artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: nuget-package
+        path: nuget
+    - name: Setup .NET variables
+      id: dotnet
+      shell: bash
+      run: |
+        major=${{ matrix.dotnet }}
+        case $major in
+          3)
+            framework=netcoreapp3.1
+            ;;
+          4)
+            framework=net472
+            # We build for .NET framework with .NET Core 3.1 SDK
+            major=3
+            ;;
+          5)
+            framework=net5.0
+            ;;
+        esac
+        version=dotnet_${major}_version
+        echo "::set-output name=version::${!version}"
+        echo "::set-output name=framework::$framework"
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ steps.dotnet.outputs.version }}
+    - name: Pin .NET Core SDK
+      run: dotnet new globaljson --sdk-version ${{ steps.dotnet.outputs.version }}
+    - name: Add local NuGet feed
+      run: |
+        dotnet new nugetconfig
+        dotnet nuget add source -n local $PWD/nuget
+    - name: Change test project references to use local NuGet package
+      run: |
+        dotnet remove ParquetSharp.DataFrame.Test reference ParquetSharp.DataFrame/ParquetSharp.DataFrame.csproj
+        dotnet add ParquetSharp.DataFrame.Test package ParquetSharp.DataFrame -v ${{ steps.get-version.outputs.version }}
+    - name: Build & Run .NET unit tests
+      run: dotnet test ParquetSharp.DataFrame.Test --configuration=Release --framework ${{ steps.dotnet.outputs.framework }}
+
+  # Virtual job that can be configured as a required check before a PR can be merged.
+  all-required-checks-done:
+    name: All required checks done
+    needs:
+      - check-format
+      - test-nuget
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All required checks done"
+
+  # Create a GitHub release and publish the NuGet packages to nuget.org when a tag is pushed.
+  publish-release:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && !github.event.repository.fork
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs: all-required-checks-done
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Check version
+      id: check-version
+      shell: pwsh
+      run: |
+        $version = (Select-Xml -Path ./ParquetSharp.DataFrame.csproj -XPath '/Project/PropertyGroup/Version/text()').node.Value
+        $tag = "${{ github.ref }}".SubString(10)
+        if (-not ($tag -eq $version)) {
+          echo "::error ::There is a mismatch between the project version ($version) and the tag ($tag)"
+          exit 1
+        }
+        echo "::set-output name=version::$version"
+    - name: Download NuGet artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: nuget-package
+        path: nuget
+    # if version contains "-" treat it as pre-release
+    # example: 1.0.0-beta1
+    - name: Create release
+      uses: softprops/action-gh-release@v1
+      with:
+        name: ParquetSharp.DataFrame ${{ steps.check-version.outputs.version }}
+        draft: true
+        prerelease: ${{ contains(steps.check-version.outputs.version, '-') }}
+        files: |
+          nuget/ParquetSharp.DataFrame.${{ steps.check-version.outputs.version }}.nupkg
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Publish to NuGet
+      run: dotnet nuget push nuget/ParquetSharp.DataFrame.${{ steps.check-version.outputs.version }}.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+bin
+obj
+
+*.user

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 bin
 obj
+nuget
 
+.idea
 *.user

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+# Contributor Code of Conduct
+
+Guiding us in our day-to-day interactions and decision-making are the values of trust, respect, collaboration and transparency. Our community welcomes participants from around the world with different experiences, personalities, unique perspectives, and great ideas to share.
+
+We expect this code of conduct to be honored by everyone who participates in the ParquetSharp community formally or informally.
+
+This code is not exhaustive or complete, and is a living document. It serves to distill our common understanding of a collaborative, shared environment and goals. We expect it to be followed in spirit as much as in the letter, so that it can enrich all of us and the technical communities in which we participate.
+
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation. 
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language.
+* Being respectful of differing viewpoints and experiences.
+* Gracefully accepting constructive criticism.
+* Attempting collaboration before conflict.
+* Focusing on what is best for the community.
+* Appreciating time and effort contributed by members.
+* Showing empathy towards other community members.
+
+
+Examples of unacceptable behavior by participants include:
+
+* Violence, threats of violence, or inciting others to commit self-harm.
+* The use of sexualized language or imagery and unwelcome sexual attention or advances.
+* Trolling, intentionally spreading misinformation, insulting/derogatory comments, and personal or political attacks, including [challenging someone’s self-identity](https://lgbtq.technology/culture.html#discussion-of-labels).
+* Public or private [harassment](https://lgbtq.technology/coc.html#harassment), aggression, deliberate intimidation, or threats.
+* [Feigning or exaggerating surprise](https://www.recurse.com/manual#no-feigned-surprise) when someone admits to not knowing something, or excusing a disrespectful communication as “ironic” or “joking”.
+* Publishing others' private information, such as a physical or electronic address, without explicit permission. This includes any sort of “outing” of any aspect of someone’s identity without their consent.
+* Abuse of the reporting process to intentionally harass or exclude others.
+* Advocating for, or encouraging, any of the above behavior.
+* Other conduct which could reasonably be considered inappropriate in a professional or community setting.
+
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+
+## Scope
+
+This Code of Conduct applies both within spaces involving this project and in other spaces involving community members. This includes the repository, its Pull Requests and Issue tracker, its Twitter community, private email communications in the context of the project, and any events where members of the project are participating, as well as adjacent communities and venues affecting the project’s members.
+
+Depending on the violation, the maintainers may decide that violations of this code of conduct that have happened outside of the scope of the community may deem an individual unwelcome, and take appropriate action to maintain the comfort and safety of its members.
+
+As a project on GitHub, this project is additionally covered by the [GitHub Community Guidelines](https://help.github.com/articles/github-community-guidelines/).
+
+
+## Enforcement
+
+While this code of conduct should be adhered to by participants, we recognize that sometimes people may have a bad day, or be unaware of some of the guidelines in this code of conduct. When that happens, or if they are violating this code of conduct, you may reply to them and point out this code of conduct. Such messages may be in public or in private, whatever is most appropriate. However, regardless of whether the message is public or not, it should still adhere to the relevant parts of this code of conduct and itself should not be abusive or disrespectful. Assume good faith; it is more likely that participants are unaware of their bad behaviour than that they intentionally try to degrade the quality of the discussion. 
+
+As a small and young project, we don’t yet have a Code of Conduct enforcement team. We encourage contributors to try to resolve issues with respectful communication - [here is an example of how to do that](https://github.com/fsprojects/fantomas/pull/649#issuecomment-599965505).
+
+Should there be difficulties in dealing with the situation or you are uncomfortable speaking up, unacceptable behavior may be reported to conduct.parquetsharp@gr-oss.io. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
+
+If you are unsure whether an incident is a violation, or whether the space where the incident took place is covered by our Code of Conduct, we encourage you to still address or report it. We would prefer to have a few extra reports where we decide to take no action than to let an incident go unnoticed and unresolved, resulting in an individual or group feeling like they can no longer participate in the community. Reports deemed as not a violation will also allow us to improve our Code of Conduct and processes surrounding it. 
+
+Participants asked to stop any harassing behavior are expected to comply immediately. Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## License
+
+This Code of Conduct is licensed under the [Creative Commons Attribution-ShareAlike 3.0 Unported License](https://creativecommons.org/licenses/by-sa/3.0/).
+
+## Attribution
+
+This Code of Conduct is informed by and adapted from multiple sources:
+
+* [Apache Code of Conduct](https://www.apache.org/foundation/policies/conduct).
+* [Auth0 Contributor Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
+* [Geek Feminism Wiki Anti-Harassment Policy](https://geekfeminism.wikia.org/wiki/Conference_anti-harassment/Policy).
+* [GitHub Community Guidelines](https://help.github.com/en/github/site-policy/github-community-guidelines).
+* [GitHub Contributor Covenant](https://www.contributor-covenant.org/).
+* [LGBTQ in Technology Slack Code of Conduct](http://lgbtq.technology/coc.html).
+* [Python Code of Conduct](https://www.python.org/psf/conduct/).
+* [Recurse Center User’s Manual](https://www.recurse.com/manual#no-feigned-surprise).
+* [Trio Code of Conduct](https://trio.readthedocs.io/en/stable/code-of-conduct.html).
+

--- a/ParquetSharp.DataFrame.DotSettings
+++ b/ParquetSharp.DataFrame.DotSettings
@@ -1,0 +1,7 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/LINE_FEED_AT_FILE_END/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSOR_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+</wpf:ResourceDictionary>

--- a/ParquetSharp.DataFrame.Test/.editorconfig
+++ b/ParquetSharp.DataFrame.Test/.editorconfig
@@ -1,0 +1,39 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.csproj]
+indent_size = 2
+resharper_xml_wrap_tags_and_pi = false
+
+[*.cs]
+csharp_new_line_before_members_in_object_initializers = false
+csharp_preserve_single_line_blocks = true
+resharper_blank_lines_after_block_statements = 0
+resharper_blank_lines_around_auto_property = 0
+resharper_blank_lines_around_single_line_type = 0
+resharper_csharp_blank_lines_around_field = 0
+resharper_csharp_insert_final_newline = true
+resharper_csharp_wrap_lines = false
+resharper_empty_block_style = multiline
+resharper_keep_existing_embedded_block_arrangement = false
+resharper_keep_existing_enum_arrangement = false
+resharper_max_attribute_length_for_same_line = 70
+resharper_place_accessorholder_attribute_on_same_line = false
+resharper_place_expr_accessor_on_single_line = true
+resharper_place_expr_method_on_single_line = true
+resharper_place_expr_property_on_single_line = true
+resharper_place_field_attribute_on_same_line = false
+resharper_place_simple_embedded_statement_on_same_line = true
+resharper_place_simple_initializer_on_single_line = false
+resharper_remove_blank_lines_near_braces_in_code = false
+resharper_remove_blank_lines_near_braces_in_declarations = false
+resharper_wrap_array_initializer_style = chop_if_long
+resharper_wrap_chained_binary_expressions = chop_if_long
+resharper_wrap_object_and_collection_initializer_style = chop_always

--- a/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
+++ b/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Data.Analysis;
+using Xunit;
+
+namespace ParquetSharp.DataFrame.Test
+{
+    public class DataFrameToParquet
+    {
+        [Fact]
+        public void TestToParquet()
+        {
+            int numRows = 10_000;
+            var testColumns = GetTestColumns();
+            var columns = new List<DataFrameColumn>(testColumns.Length);
+            foreach (var testCol in testColumns)
+            {
+                columns.Add(testCol.GetColumn(numRows));
+            }
+
+            var dataFrame = new Microsoft.Data.Analysis.DataFrame(columns);
+
+            using var dir = new UnitTestDisposableDirectory();
+            var filePath = Path.Join(dir.Info.FullName, "test.parquet");
+            dataFrame.ToParquet(filePath);
+
+            Assert.True(File.Exists(filePath));
+
+            using var fileReader = new ParquetFileReader(filePath);
+            Assert.Equal(testColumns.Length, fileReader.FileMetaData.NumColumns);
+            Assert.Equal(numRows, fileReader.FileMetaData.NumRows);
+
+            long offset = 0;
+            for (var rowGroupIdx = 0; rowGroupIdx < fileReader.FileMetaData.NumRowGroups; ++rowGroupIdx)
+            {
+                using var rowGroupReader = fileReader.RowGroup(rowGroupIdx);
+                int colIdx = 0;
+                foreach (var testCol in testColumns)
+                {
+                    using var parquetCol = rowGroupReader.Column(colIdx++);
+                    using var logicalReader = parquetCol.LogicalReader();
+                    testCol.VerifyData(logicalReader, offset);
+                }
+                offset += rowGroupReader.MetaData.NumRows;
+            }
+        }
+
+        private readonly struct TestColumn
+        {
+            public Func<int, DataFrameColumn> GetColumn { get; init; }
+
+            public Action<LogicalColumnReader, long> VerifyData { get; init; }
+        }
+
+        private static TestColumn[] GetTestColumns()
+        {
+            return new[]
+            {
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<int>("int", Enumerable.Range(0, numRows).Select(i => i)),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<int>, offset, (i, elem) => Assert.Equal(i, elem)),
+                },
+            };
+        }
+
+        private static void VerifyData<TElement>(
+            LogicalColumnReader<TElement> columnReader, long offset, Action<long, TElement> verifier)
+        {
+            var buffer = new TElement[columnReader.BufferLength];
+            long readerOffset = 0;
+            while (columnReader.HasNext)
+            {
+                var read = columnReader.ReadBatch((Span<TElement>) buffer);
+                for (int i = 0; i < read; ++i)
+                {
+                    verifier(offset + readerOffset + i, buffer[i]);
+                }
+                readerOffset += read;
+            }
+        }
+    }
+}

--- a/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
+++ b/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
@@ -60,7 +60,7 @@ namespace ParquetSharp.DataFrame.Test
         public void TestCustomParquetWriterProperties()
         {
             int numRows = 10_000;
-            var testColumns = GetTestColumns().Where(c => c.GetColumn(1).Name == "int").ToArray();
+            var testColumns = GetTestColumns().Where(c => c.GetColumn(1).Name == "int32").ToArray();
             Assert.Single(testColumns);
 
             using var dir = new UnitTestDisposableDirectory();
@@ -107,70 +107,105 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<int>("int", Enumerable.Range(0, numRows).Select(i => i)),
+                        new ByteDataFrameColumn("uint8", Enumerable.Range(0, numRows).Select(i => (byte) (i % 256))),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<byte>, offset, (i, elem) => Assert.Equal(i % 256, elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new SByteDataFrameColumn("int8", Enumerable.Range(0, numRows).Select(i => (sbyte) (i % 256 - 128))),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<sbyte>, offset, (i, elem) => Assert.Equal(i % 256 - 128, elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new UInt16DataFrameColumn("uint16", Enumerable.Range(0, numRows).Select(i => (ushort) (i % ushort.MaxValue))),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<ushort>, offset, (i, elem) => Assert.Equal(i % ushort.MaxValue, elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new Int16DataFrameColumn("int16", Enumerable.Range(0, numRows).Select(i => (short) (i % short.MaxValue))),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<short>, offset, (i, elem) => Assert.Equal(i % short.MaxValue, elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new UInt32DataFrameColumn("uint32", Enumerable.Range(0, numRows).Select(i => (uint) i)),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<uint>, offset, (i, elem) => Assert.Equal(i, elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new Int32DataFrameColumn("int32", Enumerable.Range(0, numRows).Select(i => i)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<int>, offset, (i, elem) => Assert.Equal(i, elem)),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<int>("nullable_int", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (int?) null : i)),
+                        new Int32DataFrameColumn("nullable_int32", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (int?) null : i)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<int?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (int?) i, elem)),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<long>("long", Enumerable.Range(0, numRows).Select(i => (long) i)),
+                        new Int64DataFrameColumn("int64", Enumerable.Range(0, numRows).Select(i => (long) i)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<long>, offset, Assert.Equal),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<long>("nullable_long", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (long?) null : i)),
+                        new Int64DataFrameColumn("nullable_int64", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (long?) null : i)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<long?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : i, elem)),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<float>("float", Enumerable.Range(0, numRows).Select(i => (float) i)),
+                        new SingleDataFrameColumn("float", Enumerable.Range(0, numRows).Select(i => (float) i)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<float>, offset, (i, elem) => Assert.Equal(i, elem)),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<float>("nullable_float", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (float?) i)),
+                        new SingleDataFrameColumn("nullable_float", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (float?) i)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<float?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (float?) i, elem)),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<double>("double", Enumerable.Range(0, numRows).Select(i => (double) i)),
+                        new DoubleDataFrameColumn("double", Enumerable.Range(0, numRows).Select(i => (double) i)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<double>, offset, (i, elem) => Assert.Equal(i, elem)),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<double>("nullable_double", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (double?) i)),
+                        new DoubleDataFrameColumn("nullable_double", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (double?) i)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<double?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (double?) i, elem)),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<bool>("bool", Enumerable.Range(0, numRows).Select(i => i % 2 == 0)),
+                        new BooleanDataFrameColumn("bool", Enumerable.Range(0, numRows).Select(i => i % 2 == 0)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<bool>, offset, (i, elem) => Assert.Equal(i % 2 == 0, elem)),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<bool>("nullable_bool", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (bool?) (i % 2 == 0))),
+                        new BooleanDataFrameColumn("nullable_bool", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (bool?) (i % 2 == 0))),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<bool?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : i % 2 == 0, elem)),
                 },
@@ -187,6 +222,13 @@ namespace ParquetSharp.DataFrame.Test
                         new PrimitiveDataFrameColumn<DateTime>("dateTime", Enumerable.Range(0, numRows).Select(i => new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i))),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<DateTime>, offset, (i, elem) => Assert.Equal(new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i), elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<DateTime>("nullable_dateTime", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (DateTime?) (new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i)))),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<DateTime?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i), elem)),
                 },
                 new TestColumn
                 {

--- a/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
+++ b/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
@@ -246,6 +246,30 @@ namespace ParquetSharp.DataFrame.Test
                         VerifyData(reader as LogicalColumnReader<decimal?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (new decimal(i) / 100), elem)),
                     LogicalTypeOverride = LogicalType.Decimal(29, 3),
                 },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new Int32DataFrameColumn("int_as_byte", Enumerable.Range(0, numRows).Select(i => i % 256)),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<byte>, offset, (i, elem) => Assert.Equal(i % 256, elem)),
+                    LogicalTypeOverride = LogicalType.Int(8, false),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new Int32DataFrameColumn("int_as_date", Enumerable.Range(0, numRows).Select(i => i)),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<Date>, offset, (i, elem) => Assert.Equal(new Date(1970, 1, 1).AddDays((int) i), elem)),
+                    LogicalTypeOverride = LogicalType.Date(),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new Int32DataFrameColumn("int_as_time", Enumerable.Range(0, numRows).Select(i => i)),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<TimeSpan>, offset, (i, elem) => Assert.Equal(TimeSpan.FromMilliseconds(i), elem)),
+                    LogicalTypeOverride = LogicalType.Time(isAdjustedToUtc: true, TimeUnit.Millis),
+                },
             };
         }
 

--- a/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
+++ b/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
@@ -26,6 +26,7 @@ namespace ParquetSharp.DataFrame.Test
                 {
                     logicalTypeOverrides[dataFrameCol.Name] = testCol.LogicalTypeOverride;
                 }
+
                 columns.Add(dataFrameCol);
             }
 
@@ -52,6 +53,7 @@ namespace ParquetSharp.DataFrame.Test
                     using var logicalReader = parquetCol.LogicalReader();
                     testCol.VerifyData(logicalReader, offset);
                 }
+
                 offset += rowGroupReader.MetaData.NumRows;
             }
         }
@@ -67,7 +69,7 @@ namespace ParquetSharp.DataFrame.Test
             var filePath = Path.Join(dir.Info.FullName, "test.parquet");
 
             {
-                var columns = new[] {testColumns[0].GetColumn(numRows)};
+                var columns = new[] { testColumns[0].GetColumn(numRows) };
                 var dataFrame = new Microsoft.Data.Analysis.DataFrame(columns);
 
                 using var propertiesBuilder = new WriterPropertiesBuilder();
@@ -107,35 +109,35 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new ByteDataFrameColumn("uint8", Enumerable.Range(0, numRows).Select(i => (byte) (i % 256))),
+                        new ByteDataFrameColumn("uint8", Enumerable.Range(0, numRows).Select(i => (byte)(i % 256))),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<byte>, offset, (i, elem) => Assert.Equal(i % 256, elem)),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new SByteDataFrameColumn("int8", Enumerable.Range(0, numRows).Select(i => (sbyte) (i % 256 - 128))),
+                        new SByteDataFrameColumn("int8", Enumerable.Range(0, numRows).Select(i => (sbyte)(i % 256 - 128))),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<sbyte>, offset, (i, elem) => Assert.Equal(i % 256 - 128, elem)),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new UInt16DataFrameColumn("uint16", Enumerable.Range(0, numRows).Select(i => (ushort) (i % ushort.MaxValue))),
+                        new UInt16DataFrameColumn("uint16", Enumerable.Range(0, numRows).Select(i => (ushort)(i % ushort.MaxValue))),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<ushort>, offset, (i, elem) => Assert.Equal(i % ushort.MaxValue, elem)),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new Int16DataFrameColumn("int16", Enumerable.Range(0, numRows).Select(i => (short) (i % short.MaxValue))),
+                        new Int16DataFrameColumn("int16", Enumerable.Range(0, numRows).Select(i => (short)(i % short.MaxValue))),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<short>, offset, (i, elem) => Assert.Equal(i % short.MaxValue, elem)),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new UInt32DataFrameColumn("uint32", Enumerable.Range(0, numRows).Select(i => (uint) i)),
+                        new UInt32DataFrameColumn("uint32", Enumerable.Range(0, numRows).Select(i => (uint)i)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<uint>, offset, (i, elem) => Assert.Equal(i, elem)),
                 },
@@ -149,49 +151,49 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new Int32DataFrameColumn("nullable_int32", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (int?) null : i)),
+                        new Int32DataFrameColumn("nullable_int32", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (int?)null : i)),
                     VerifyData = (reader, offset) =>
-                        VerifyData(reader as LogicalColumnReader<int?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (int?) i, elem)),
+                        VerifyData(reader as LogicalColumnReader<int?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (int?)i, elem)),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new Int64DataFrameColumn("int64", Enumerable.Range(0, numRows).Select(i => (long) i)),
+                        new Int64DataFrameColumn("int64", Enumerable.Range(0, numRows).Select(i => (long)i)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<long>, offset, Assert.Equal),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new Int64DataFrameColumn("nullable_int64", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (long?) null : i)),
+                        new Int64DataFrameColumn("nullable_int64", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (long?)null : i)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<long?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : i, elem)),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new SingleDataFrameColumn("float", Enumerable.Range(0, numRows).Select(i => (float) i)),
+                        new SingleDataFrameColumn("float", Enumerable.Range(0, numRows).Select(i => (float)i)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<float>, offset, (i, elem) => Assert.Equal(i, elem)),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new SingleDataFrameColumn("nullable_float", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (float?) i)),
+                        new SingleDataFrameColumn("nullable_float", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (float?)i)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<float?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : i, elem)),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new DoubleDataFrameColumn("double", Enumerable.Range(0, numRows).Select(i => (double) i)),
+                        new DoubleDataFrameColumn("double", Enumerable.Range(0, numRows).Select(i => (double)i)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<double>, offset, (i, elem) => Assert.Equal(i, elem)),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new DoubleDataFrameColumn("nullable_double", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (double?) i)),
+                        new DoubleDataFrameColumn("nullable_double", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (double?)i)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<double?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : i, elem)),
                 },
@@ -205,7 +207,7 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new BooleanDataFrameColumn("nullable_bool", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (bool?) (i % 2 == 0))),
+                        new BooleanDataFrameColumn("nullable_bool", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (bool?)(i % 2 == 0))),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<bool?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : i % 2 == 0, elem)),
                 },
@@ -226,7 +228,7 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<DateTime>("nullable_dateTime", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (DateTime?) (new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i)))),
+                        new PrimitiveDataFrameColumn<DateTime>("nullable_dateTime", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (DateTime?)(new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i)))),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<DateTime?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i), elem)),
                 },
@@ -240,7 +242,7 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<TimeSpan>("nullable_timeSpan", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (TimeSpan?) TimeSpan.FromMilliseconds(i))),
+                        new PrimitiveDataFrameColumn<TimeSpan>("nullable_timeSpan", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (TimeSpan?)TimeSpan.FromMilliseconds(i))),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<TimeSpan?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : TimeSpan.FromMilliseconds(i), elem)),
                 },
@@ -249,14 +251,14 @@ namespace ParquetSharp.DataFrame.Test
                     GetColumn = numRows =>
                         new PrimitiveDataFrameColumn<Date>("date", Enumerable.Range(0, numRows).Select(i => new Date(i))),
                     VerifyData = (reader, offset) =>
-                        VerifyData(reader as LogicalColumnReader<Date>, offset, (i, elem) => Assert.Equal(new Date((int) i), elem)),
+                        VerifyData(reader as LogicalColumnReader<Date>, offset, (i, elem) => Assert.Equal(new Date((int)i), elem)),
                 },
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<Date>("nullable_date", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (Date?) new Date(i))),
+                        new PrimitiveDataFrameColumn<Date>("nullable_date", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (Date?)new Date(i))),
                     VerifyData = (reader, offset) =>
-                        VerifyData(reader as LogicalColumnReader<Date?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : new Date((int) i), elem)),
+                        VerifyData(reader as LogicalColumnReader<Date?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : new Date((int)i), elem)),
                 },
                 new TestColumn
                 {
@@ -268,7 +270,7 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<DateTimeNanos>("nullable_dateTimeNanos", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (DateTimeNanos?) new DateTimeNanos(i))),
+                        new PrimitiveDataFrameColumn<DateTimeNanos>("nullable_dateTimeNanos", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (DateTimeNanos?)new DateTimeNanos(i))),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<DateTimeNanos?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : new DateTimeNanos(i), elem)),
                 },
@@ -282,7 +284,7 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<TimeSpanNanos>("nullable_timeSpanNanos", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (TimeSpanNanos?) new TimeSpanNanos(i))),
+                        new PrimitiveDataFrameColumn<TimeSpanNanos>("nullable_timeSpanNanos", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (TimeSpanNanos?)new TimeSpanNanos(i))),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<TimeSpanNanos?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : new TimeSpanNanos(i), elem)),
                 },
@@ -297,7 +299,7 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new DecimalDataFrameColumn("nullable_decimal", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (decimal?) (new decimal(i) / 100))),
+                        new DecimalDataFrameColumn("nullable_decimal", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (decimal?)(new decimal(i) / 100))),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<decimal?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (new decimal(i) / 100), elem)),
                     LogicalTypeOverride = LogicalType.Decimal(29, 3),
@@ -315,7 +317,7 @@ namespace ParquetSharp.DataFrame.Test
                     GetColumn = numRows =>
                         new Int32DataFrameColumn("int_as_date", Enumerable.Range(0, numRows).Select(i => i)),
                     VerifyData = (reader, offset) =>
-                        VerifyData(reader as LogicalColumnReader<Date>, offset, (i, elem) => Assert.Equal(new Date(1970, 1, 1).AddDays((int) i), elem)),
+                        VerifyData(reader as LogicalColumnReader<Date>, offset, (i, elem) => Assert.Equal(new Date(1970, 1, 1).AddDays((int)i), elem)),
                     LogicalTypeOverride = LogicalType.Date(),
                 },
                 new TestColumn
@@ -337,11 +339,12 @@ namespace ParquetSharp.DataFrame.Test
             long readerOffset = 0;
             while (columnReader.HasNext)
             {
-                var read = columnReader.ReadBatch((Span<TElement>) buffer);
+                var read = columnReader.ReadBatch((Span<TElement>)buffer);
                 for (int i = 0; i < read; ++i)
                 {
                     verifier(offset + readerOffset + i, buffer[i]);
                 }
+
                 readerOffset += read;
             }
         }

--- a/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
+++ b/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
@@ -94,7 +94,7 @@ namespace ParquetSharp.DataFrame.Test
 
             public Action<LogicalColumnReader, long> VerifyData { get; init; }
 
-            public LogicalType LogicalTypeOverride { get; init; }
+            public LogicalType? LogicalTypeOverride { get; init; }
         }
 
         private static TestColumn[] GetTestColumns()
@@ -205,10 +205,10 @@ namespace ParquetSharp.DataFrame.Test
         }
 
         private static void VerifyData<TElement>(
-            LogicalColumnReader<TElement> columnReader, long offset, Action<long, TElement> verifier)
+            LogicalColumnReader<TElement>? columnReader, long offset, Action<long, TElement> verifier)
         {
             Assert.NotNull(columnReader);
-            var buffer = new TElement[columnReader.BufferLength];
+            var buffer = new TElement[columnReader!.BufferLength];
             long readerOffset = 0;
             while (columnReader.HasNext)
             {

--- a/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
+++ b/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
@@ -75,6 +75,20 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<long>("long", Enumerable.Range(0, numRows).Select(i => (long) i)),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<long>, offset, Assert.Equal),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<long>("nullable_long", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (long?) null : i)),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<long?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : i, elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
                         new PrimitiveDataFrameColumn<float>("float", Enumerable.Range(0, numRows).Select(i => (float) i)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<float>, offset, (i, elem) => Assert.Equal(i, elem)),

--- a/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
+++ b/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
@@ -33,7 +33,7 @@ namespace ParquetSharp.DataFrame.Test
             var dataFrame = new Microsoft.Data.Analysis.DataFrame(columns);
 
             using var dir = new UnitTestDisposableDirectory();
-            var filePath = Path.Join(dir.Info.FullName, "test.parquet");
+            var filePath = Path.Combine(dir.Info.FullName, "test.parquet");
             dataFrame.ToParquet(filePath, logicalTypeOverrides: logicalTypeOverrides);
 
             Assert.True(File.Exists(filePath));
@@ -66,7 +66,7 @@ namespace ParquetSharp.DataFrame.Test
             Assert.Single(testColumns);
 
             using var dir = new UnitTestDisposableDirectory();
-            var filePath = Path.Join(dir.Info.FullName, "test.parquet");
+            var filePath = Path.Combine(dir.Info.FullName, "test.parquet");
 
             {
                 var columns = new[] { testColumns[0].GetColumn(numRows) };

--- a/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
+++ b/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
@@ -233,6 +233,20 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<TimeSpan>("timeSpan", Enumerable.Range(0, numRows).Select(i => TimeSpan.FromMilliseconds(i))),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<TimeSpan>, offset, (i, elem) => Assert.Equal(TimeSpan.FromMilliseconds(i), elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<TimeSpan>("nullable_timeSpan", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (TimeSpan?) TimeSpan.FromMilliseconds(i))),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<TimeSpan?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : TimeSpan.FromMilliseconds(i), elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
                         new DecimalDataFrameColumn("decimal", Enumerable.Range(0, numRows).Select(i => new decimal(i) / 100)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<decimal>, offset, (i, elem) => Assert.Equal(new decimal(i) / 100, elem)),

--- a/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
+++ b/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
@@ -65,12 +65,90 @@ namespace ParquetSharp.DataFrame.Test
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<int>, offset, (i, elem) => Assert.Equal(i, elem)),
                 },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<int>("nullable_int", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (int?) null : i)),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<int?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (int?) i, elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<float>("float", Enumerable.Range(0, numRows).Select(i => (float) i)),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<float>, offset, (i, elem) => Assert.Equal(i, elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<float>("nullable_float", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (float?) i)),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<float?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (float?) i, elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<double>("double", Enumerable.Range(0, numRows).Select(i => (double) i)),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<double>, offset, (i, elem) => Assert.Equal(i, elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<double>("nullable_double", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (double?) i)),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<double?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (double?) i, elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<bool>("bool", Enumerable.Range(0, numRows).Select(i => i % 2 == 0)),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<bool>, offset, (i, elem) => Assert.Equal(i % 2 == 0, elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<bool>("nullable_bool", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (bool?) (i % 2 == 0))),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<bool?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : i % 2 == 0, elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new StringDataFrameColumn("string", Enumerable.Range(0, numRows).Select(i => i.ToString())),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<string>, offset, (i, elem) => Assert.Equal(i.ToString(), elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<DateTime>("dateTime", Enumerable.Range(0, numRows).Select(i => new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i))),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<DateTime>, offset, (i, elem) => Assert.Equal(new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i), elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new DecimalDataFrameColumn("decimal", Enumerable.Range(0, numRows).Select(i => new decimal(i) / 100)),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<decimal>, offset, (i, elem) => Assert.Equal(new decimal(i) / 100, elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new DecimalDataFrameColumn("nullable_decimal", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (decimal?) (new decimal(i) / 100))),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<decimal?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (new decimal(i) / 100), elem)),
+                },
             };
         }
 
         private static void VerifyData<TElement>(
             LogicalColumnReader<TElement> columnReader, long offset, Action<long, TElement> verifier)
         {
+            Assert.NotNull(columnReader);
             var buffer = new TElement[columnReader.BufferLength];
             long readerOffset = 0;
             while (columnReader.HasNext)

--- a/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
+++ b/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
@@ -167,7 +167,7 @@ namespace ParquetSharp.DataFrame.Test
                     GetColumn = numRows =>
                         new Int64DataFrameColumn("nullable_int64", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (long?)null : i)),
                     VerifyData = (reader, offset) =>
-                        VerifyData(reader as LogicalColumnReader<long?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : i, elem)),
+                        VerifyData(reader as LogicalColumnReader<long?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (long?)i, elem)),
                 },
                 new TestColumn
                 {
@@ -181,7 +181,7 @@ namespace ParquetSharp.DataFrame.Test
                     GetColumn = numRows =>
                         new SingleDataFrameColumn("nullable_float", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (float?)i)),
                     VerifyData = (reader, offset) =>
-                        VerifyData(reader as LogicalColumnReader<float?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : i, elem)),
+                        VerifyData(reader as LogicalColumnReader<float?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (float?)i, elem)),
                 },
                 new TestColumn
                 {
@@ -195,7 +195,7 @@ namespace ParquetSharp.DataFrame.Test
                     GetColumn = numRows =>
                         new DoubleDataFrameColumn("nullable_double", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (double?)i)),
                     VerifyData = (reader, offset) =>
-                        VerifyData(reader as LogicalColumnReader<double?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : i, elem)),
+                        VerifyData(reader as LogicalColumnReader<double?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (double?)i, elem)),
                 },
                 new TestColumn
                 {
@@ -209,7 +209,7 @@ namespace ParquetSharp.DataFrame.Test
                     GetColumn = numRows =>
                         new BooleanDataFrameColumn("nullable_bool", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (bool?)(i % 2 == 0))),
                     VerifyData = (reader, offset) =>
-                        VerifyData(reader as LogicalColumnReader<bool?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : i % 2 == 0, elem)),
+                        VerifyData(reader as LogicalColumnReader<bool?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (bool?)(i % 2 == 0), elem)),
                 },
                 new TestColumn
                 {
@@ -228,9 +228,11 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<DateTime>("nullable_dateTime", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (DateTime?)(new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i)))),
+                        new PrimitiveDataFrameColumn<DateTime>("nullable_dateTime", Enumerable.Range(0, numRows).Select(
+                            i => i % 10 == 0 ? null : (DateTime?)(new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i)))),
                     VerifyData = (reader, offset) =>
-                        VerifyData(reader as LogicalColumnReader<DateTime?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i), elem)),
+                        VerifyData(reader as LogicalColumnReader<DateTime?>, offset, (i, elem) =>
+                            Assert.Equal(i % 10 == 0 ? null : (DateTime?)(new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i)), elem)),
                 },
                 new TestColumn
                 {
@@ -242,9 +244,11 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<TimeSpan>("nullable_timeSpan", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (TimeSpan?)TimeSpan.FromMilliseconds(i))),
+                        new PrimitiveDataFrameColumn<TimeSpan>("nullable_timeSpan", Enumerable.Range(0, numRows).Select(
+                            i => i % 10 == 0 ? null : (TimeSpan?)TimeSpan.FromMilliseconds(i))),
                     VerifyData = (reader, offset) =>
-                        VerifyData(reader as LogicalColumnReader<TimeSpan?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : TimeSpan.FromMilliseconds(i), elem)),
+                        VerifyData(reader as LogicalColumnReader<TimeSpan?>, offset, (i, elem) => Assert.Equal(
+                            i % 10 == 0 ? null : (TimeSpan?)TimeSpan.FromMilliseconds(i), elem)),
                 },
                 new TestColumn
                 {
@@ -258,7 +262,7 @@ namespace ParquetSharp.DataFrame.Test
                     GetColumn = numRows =>
                         new PrimitiveDataFrameColumn<Date>("nullable_date", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (Date?)new Date(i))),
                     VerifyData = (reader, offset) =>
-                        VerifyData(reader as LogicalColumnReader<Date?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : new Date((int)i), elem)),
+                        VerifyData(reader as LogicalColumnReader<Date?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (Date?)new Date((int)i), elem)),
                 },
                 new TestColumn
                 {
@@ -270,9 +274,11 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<DateTimeNanos>("nullable_dateTimeNanos", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (DateTimeNanos?)new DateTimeNanos(i))),
+                        new PrimitiveDataFrameColumn<DateTimeNanos>("nullable_dateTimeNanos", Enumerable.Range(0, numRows).Select(
+                            i => i % 10 == 0 ? null : (DateTimeNanos?)new DateTimeNanos(i))),
                     VerifyData = (reader, offset) =>
-                        VerifyData(reader as LogicalColumnReader<DateTimeNanos?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : new DateTimeNanos(i), elem)),
+                        VerifyData(reader as LogicalColumnReader<DateTimeNanos?>, offset, (i, elem) => Assert.Equal(
+                            i % 10 == 0 ? null : (DateTimeNanos?)new DateTimeNanos(i), elem)),
                 },
                 new TestColumn
                 {
@@ -284,9 +290,11 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new PrimitiveDataFrameColumn<TimeSpanNanos>("nullable_timeSpanNanos", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (TimeSpanNanos?)new TimeSpanNanos(i))),
+                        new PrimitiveDataFrameColumn<TimeSpanNanos>("nullable_timeSpanNanos", Enumerable.Range(0, numRows).Select(
+                            i => i % 10 == 0 ? null : (TimeSpanNanos?)new TimeSpanNanos(i))),
                     VerifyData = (reader, offset) =>
-                        VerifyData(reader as LogicalColumnReader<TimeSpanNanos?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : new TimeSpanNanos(i), elem)),
+                        VerifyData(reader as LogicalColumnReader<TimeSpanNanos?>, offset, (i, elem) => Assert.Equal(
+                            i % 10 == 0 ? null : (TimeSpanNanos?)new TimeSpanNanos(i), elem)),
                 },
                 new TestColumn
                 {
@@ -299,9 +307,11 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     GetColumn = numRows =>
-                        new DecimalDataFrameColumn("nullable_decimal", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (decimal?)(new decimal(i) / 100))),
+                        new DecimalDataFrameColumn("nullable_decimal", Enumerable.Range(0, numRows).Select(
+                            i => i % 10 == 0 ? null : (decimal?)(new decimal(i) / 100))),
                     VerifyData = (reader, offset) =>
-                        VerifyData(reader as LogicalColumnReader<decimal?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (new decimal(i) / 100), elem)),
+                        VerifyData(reader as LogicalColumnReader<decimal?>, offset, (i, elem) => Assert.Equal(
+                            i % 10 == 0 ? null : (decimal?)(new decimal(i) / 100), elem)),
                     LogicalTypeOverride = LogicalType.Decimal(29, 3),
                 },
                 new TestColumn

--- a/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
+++ b/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
@@ -93,7 +93,7 @@ namespace ParquetSharp.DataFrame.Test
             }
         }
 
-        private readonly struct TestColumn
+        private struct TestColumn
         {
             public Func<int, DataFrameColumn> GetColumn { get; init; }
 

--- a/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
+++ b/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
@@ -179,7 +179,7 @@ namespace ParquetSharp.DataFrame.Test
                     GetColumn = numRows =>
                         new SingleDataFrameColumn("nullable_float", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (float?) i)),
                     VerifyData = (reader, offset) =>
-                        VerifyData(reader as LogicalColumnReader<float?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (float?) i, elem)),
+                        VerifyData(reader as LogicalColumnReader<float?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : i, elem)),
                 },
                 new TestColumn
                 {
@@ -193,7 +193,7 @@ namespace ParquetSharp.DataFrame.Test
                     GetColumn = numRows =>
                         new DoubleDataFrameColumn("nullable_double", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (double?) i)),
                     VerifyData = (reader, offset) =>
-                        VerifyData(reader as LogicalColumnReader<double?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : (double?) i, elem)),
+                        VerifyData(reader as LogicalColumnReader<double?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : i, elem)),
                 },
                 new TestColumn
                 {

--- a/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
+++ b/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
@@ -7,6 +7,9 @@ using Xunit;
 
 namespace ParquetSharp.DataFrame.Test
 {
+    /// <summary>
+    /// Test writing DataFrames to Parquet
+    /// </summary>
     public class DataFrameToParquet
     {
         [Fact]

--- a/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
+++ b/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
@@ -261,6 +261,34 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<DateTimeNanos>("dateTimeNanos", Enumerable.Range(0, numRows).Select(i => new DateTimeNanos(i))),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<DateTimeNanos>, offset, (i, elem) => Assert.Equal(new DateTimeNanos(i), elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<DateTimeNanos>("nullable_dateTimeNanos", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (DateTimeNanos?) new DateTimeNanos(i))),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<DateTimeNanos?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : new DateTimeNanos(i), elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<TimeSpanNanos>("timeSpanNanos", Enumerable.Range(0, numRows).Select(i => new TimeSpanNanos(i))),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<TimeSpanNanos>, offset, (i, elem) => Assert.Equal(new TimeSpanNanos(i), elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<TimeSpanNanos>("nullable_timeSpanNanos", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (TimeSpanNanos?) new TimeSpanNanos(i))),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<TimeSpanNanos?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : new TimeSpanNanos(i), elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
                         new DecimalDataFrameColumn("decimal", Enumerable.Range(0, numRows).Select(i => new decimal(i) / 100)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<decimal>, offset, (i, elem) => Assert.Equal(new decimal(i) / 100, elem)),

--- a/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
+++ b/ParquetSharp.DataFrame.Test/DataFrameToParquet.cs
@@ -247,6 +247,20 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<Date>("date", Enumerable.Range(0, numRows).Select(i => new Date(i))),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<Date>, offset, (i, elem) => Assert.Equal(new Date((int) i), elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
+                        new PrimitiveDataFrameColumn<Date>("nullable_date", Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? null : (Date?) new Date(i))),
+                    VerifyData = (reader, offset) =>
+                        VerifyData(reader as LogicalColumnReader<Date?>, offset, (i, elem) => Assert.Equal(i % 10 == 0 ? null : new Date((int) i), elem)),
+                },
+                new TestColumn
+                {
+                    GetColumn = numRows =>
                         new DecimalDataFrameColumn("decimal", Enumerable.Range(0, numRows).Select(i => new decimal(i) / 100)),
                     VerifyData = (reader, offset) =>
                         VerifyData(reader as LogicalColumnReader<decimal>, offset, (i, elem) => Assert.Equal(new decimal(i) / 100, elem)),

--- a/ParquetSharp.DataFrame.Test/IsExternalInit.cs
+++ b/ParquetSharp.DataFrame.Test/IsExternalInit.cs
@@ -1,0 +1,6 @@
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+    // Needed to support init setters for dotnet < 5.0
+    internal static class IsExternalInit {}
+}

--- a/ParquetSharp.DataFrame.Test/IsExternalInit.cs
+++ b/ParquetSharp.DataFrame.Test/IsExternalInit.cs
@@ -1,6 +1,9 @@
 // ReSharper disable once CheckNamespace
+
 namespace System.Runtime.CompilerServices
 {
     // Needed to support init setters for dotnet < 5.0
-    internal static class IsExternalInit {}
+    internal static class IsExternalInit
+    {
+    }
 }

--- a/ParquetSharp.DataFrame.Test/ParquetSharp.DataFrame.Test.csproj
+++ b/ParquetSharp.DataFrame.Test/ParquetSharp.DataFrame.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-
+    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/ParquetSharp.DataFrame.Test/ParquetSharp.DataFrame.Test.csproj
+++ b/ParquetSharp.DataFrame.Test/ParquetSharp.DataFrame.Test.csproj
@@ -1,9 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
+    <AssemblyName>ParquetSharp.DataFrame.Test</AssemblyName>
+    <RootNamespace>ParquetSharp.DataFrame.Test</RootNamespace>
     <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ParquetSharp.DataFrame.Test/ParquetSharp.DataFrame.Test.csproj
+++ b/ParquetSharp.DataFrame.Test/ParquetSharp.DataFrame.Test.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Analysis" Version="0.19.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="ParquetSharp" Version="4.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ParquetSharp.DataFrame\ParquetSharp.DataFrame.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ParquetSharp.DataFrame.Test/ParquetSharp.DataFrame.Test.csproj
+++ b/ParquetSharp.DataFrame.Test/ParquetSharp.DataFrame.Test.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>ParquetSharp.DataFrame.Test</RootNamespace>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PlatformTarget Condition="'$(TargetFramework)'=='net472'">x64</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
+++ b/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
@@ -6,6 +6,9 @@ using Xunit;
 
 namespace ParquetSharp.DataFrame.Test
 {
+    /// <summary>
+    /// Test reading Parquet data into a DataFrame
+    /// </summary>
     public class ParquetToDataFrame
     {
         [Fact]

--- a/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
+++ b/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Linq;
+using Microsoft.Data.Analysis;
 using ParquetSharp.IO;
 using Xunit;
 
@@ -14,29 +16,35 @@ namespace ParquetSharp.DataFrame.Test
                 new Column<int>("int"),
                 new Column<double>("double"),
                 new Column<string>("string"),
-                new Column<bool>("bool")
+                new Column<bool>("bool"),
+                new Column<DateTime>("dateTime"),
             };
 
             const int numRows = 1000;
-                
+
             using var buffer = new ResizableBuffer();
             using (var output = new BufferOutputStream(buffer))
             {
                 var propertiesBuilder = new WriterPropertiesBuilder();
                 using var fileWriter = new ParquetFileWriter(output, columns, propertiesBuilder.Build());
                 using var rowGroupWriter = fileWriter.AppendRowGroup();
-                
+
                 using var intCol = rowGroupWriter.NextColumn().LogicalWriter<int>();
                 intCol.WriteBatch(Enumerable.Range(0, numRows).ToArray());
-                
+
                 using var doubleCol = rowGroupWriter.NextColumn().LogicalWriter<double>();
                 doubleCol.WriteBatch(Enumerable.Range(0, numRows).Select(i => (double) i).ToArray());
-                
+
                 using var stringCol = rowGroupWriter.NextColumn().LogicalWriter<string>();
                 stringCol.WriteBatch(Enumerable.Range(0, numRows).Select(i => i.ToString()).ToArray());
-                
+
                 using var boolCol = rowGroupWriter.NextColumn().LogicalWriter<bool>();
                 boolCol.WriteBatch(Enumerable.Range(0, numRows).Select(i => i % 2 == 0).ToArray());
+
+                using var dateTimeCol = rowGroupWriter.NextColumn().LogicalWriter<DateTime>();
+                dateTimeCol.WriteBatch(
+                    Enumerable.Range(0, numRows)
+                        .Select(i => new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i)).ToArray());
 
                 fileWriter.Close();
             }
@@ -45,9 +53,24 @@ namespace ParquetSharp.DataFrame.Test
             {
                 using var fileReader = new ParquetFileReader(input);
                 var dataFrame = fileReader.ToDataFrame();
-                
-                Assert.Equal(4, dataFrame.Columns.Count);
-                    
+
+                Assert.Equal(columns.Length, dataFrame.Columns.Count);
+
+                var intCol = dataFrame["int"];
+                Assert.IsType<PrimitiveDataFrameColumn<int>>(intCol);
+
+                var doubleCol = dataFrame["double"];
+                Assert.IsType<PrimitiveDataFrameColumn<double>>(doubleCol);
+
+                var stringCol = dataFrame["string"];
+                Assert.IsType<StringDataFrameColumn>(stringCol);
+
+                var boolCol = dataFrame["bool"];
+                Assert.IsType<BooleanDataFrameColumn>(boolCol);
+
+                var dateTimeCol = dataFrame["dateTime"];
+                Assert.IsType<PrimitiveDataFrameColumn<DateTime>>(dateTimeCol);
+
                 fileReader.Close();
             }
         }

--- a/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
+++ b/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
@@ -131,7 +131,7 @@ namespace ParquetSharp.DataFrame.Test
             public Type ExpectedColumnType { get; init;  }
             public Action<int, ColumnWriter> WriteColumn { get; init;  }
             public Action<DataFrameColumn> VerifyColumn { get; init;  }
-            public Func<long, long> NullCount { get; init; }
+            public Func<long, long>? NullCount { get; init; }
         }
 
         private static TestColumn[] GetTestColumns()
@@ -203,7 +203,7 @@ namespace ParquetSharp.DataFrame.Test
                     {
                         for (long i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal(i % 10 == 0 ? null : i, column[i]);
+                            Assert.Equal(i % 10 == 0 ? null : (long?) i, column[i]);
                         }
                     },
                     NullCount = numRows => numRows / 10,

--- a/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
+++ b/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
@@ -442,6 +442,44 @@ namespace ParquetSharp.DataFrame.Test
                 },
                 new TestColumn
                 {
+                    ParquetColumn = new Column<DateTimeNanos>("dateTimeNanos"),
+                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<DateTimeNanos>),
+                    WriteColumn = (numRows, columnWriter) =>
+                    {
+                        using var logicalWriter = columnWriter.LogicalWriter<DateTimeNanos>();
+                        logicalWriter.WriteBatch(
+                            Enumerable.Range(0, numRows)
+                                .Select(i => new DateTimeNanos(i)).ToArray());
+                    },
+                    VerifyColumn = column =>
+                    {
+                        for (int i = 0; i < column.Length; ++i)
+                        {
+                            Assert.Equal(new DateTimeNanos(i), column[i]);
+                        }
+                    }
+                },
+                new TestColumn
+                {
+                    ParquetColumn = new Column<DateTimeNanos?>("nullable_dateTimeNanos"),
+                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<DateTimeNanos>),
+                    WriteColumn = (numRows, columnWriter) =>
+                    {
+                        using var logicalWriter = columnWriter.LogicalWriter<DateTimeNanos?>();
+                        logicalWriter.WriteBatch(
+                            Enumerable.Range(0, numRows)
+                                .Select(i => (DateTimeNanos?) new DateTimeNanos(i)).ToArray());
+                    },
+                    VerifyColumn = column =>
+                    {
+                        for (int i = 0; i < column.Length; ++i)
+                        {
+                            Assert.Equal(new DateTimeNanos(i), column[i]);
+                        }
+                    }
+                },
+                new TestColumn
+                {
                     ParquetColumn = new Column<decimal>("decimal", LogicalType.Decimal(29, 3)),
                     ExpectedColumnType = typeof(DecimalDataFrameColumn),
                     WriteColumn = (numRows, columnWriter) =>
@@ -559,6 +597,40 @@ namespace ParquetSharp.DataFrame.Test
                         for (int i = 0; i < column.Length; ++i)
                         {
                             Assert.Equal(TimeSpan.FromMilliseconds(i), column[i]);
+                        }
+                    }
+                },
+                new TestColumn
+                {
+                    ParquetColumn = new Column<TimeSpanNanos>("time_ns", LogicalType.Time(isAdjustedToUtc: true, TimeUnit.Nanos)),
+                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<TimeSpanNanos>),
+                    WriteColumn = (numRows, columnWriter) =>
+                    {
+                        using var logicalWriter = columnWriter.LogicalWriter<TimeSpanNanos>();
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => new TimeSpanNanos(i)).ToArray());
+                    },
+                    VerifyColumn = column =>
+                    {
+                        for (int i = 0; i < column.Length; ++i)
+                        {
+                            Assert.Equal(new TimeSpanNanos(i), column[i]);
+                        }
+                    }
+                },
+                new TestColumn
+                {
+                    ParquetColumn = new Column<TimeSpanNanos?>("nullable_time_ns", LogicalType.Time(isAdjustedToUtc: true, TimeUnit.Nanos)),
+                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<TimeSpanNanos>),
+                    WriteColumn = (numRows, columnWriter) =>
+                    {
+                        using var logicalWriter = columnWriter.LogicalWriter<TimeSpanNanos?>();
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (TimeSpanNanos?) new TimeSpanNanos(i)).ToArray());
+                    },
+                    VerifyColumn = column =>
+                    {
+                        for (int i = 0; i < column.Length; ++i)
+                        {
+                            Assert.Equal(new TimeSpanNanos(i), column[i]);
                         }
                     }
                 },

--- a/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
+++ b/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
@@ -143,8 +143,76 @@ namespace ParquetSharp.DataFrame.Test
             {
                 new TestColumn
                 {
+                    ParquetColumn = new Column<byte>("uint8"),
+                    ExpectedColumnType = typeof(ByteDataFrameColumn),
+                    WriteColumn = (numRows, columnWriter) =>
+                    {
+                        using var logicalWriter = columnWriter.LogicalWriter<byte>();
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (byte) (i % 256)).ToArray());
+                    },
+                    VerifyColumn = column =>
+                    {
+                        for (int i = 0; i < column.Length; ++i)
+                        {
+                            Assert.Equal((byte) (i % 256), column[i]);
+                        }
+                    }
+                },
+                new TestColumn
+                {
+                    ParquetColumn = new Column<sbyte>("int8"),
+                    ExpectedColumnType = typeof(SByteDataFrameColumn),
+                    WriteColumn = (numRows, columnWriter) =>
+                    {
+                        using var logicalWriter = columnWriter.LogicalWriter<sbyte>();
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (sbyte) (i % 256 - 128)).ToArray());
+                    },
+                    VerifyColumn = column =>
+                    {
+                        for (int i = 0; i < column.Length; ++i)
+                        {
+                            Assert.Equal((sbyte) (i % 256 - 128), column[i]);
+                        }
+                    }
+                },
+                new TestColumn
+                {
+                    ParquetColumn = new Column<ushort>("uint16"),
+                    ExpectedColumnType = typeof(UInt16DataFrameColumn),
+                    WriteColumn = (numRows, columnWriter) =>
+                    {
+                        using var logicalWriter = columnWriter.LogicalWriter<ushort>();
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (ushort) (i % ushort.MaxValue)).ToArray());
+                    },
+                    VerifyColumn = column =>
+                    {
+                        for (int i = 0; i < column.Length; ++i)
+                        {
+                            Assert.Equal((ushort) (i % ushort.MaxValue), column[i]);
+                        }
+                    }
+                },
+                new TestColumn
+                {
+                    ParquetColumn = new Column<short>("int16"),
+                    ExpectedColumnType = typeof(Int16DataFrameColumn),
+                    WriteColumn = (numRows, columnWriter) =>
+                    {
+                        using var logicalWriter = columnWriter.LogicalWriter<short>();
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (short) (i % short.MaxValue)).ToArray());
+                    },
+                    VerifyColumn = column =>
+                    {
+                        for (int i = 0; i < column.Length; ++i)
+                        {
+                            Assert.Equal((short) (i % short.MaxValue), column[i]);
+                        }
+                    }
+                },
+                new TestColumn
+                {
                     ParquetColumn = new Column<int>("int"),
-                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<int>),
+                    ExpectedColumnType = typeof(Int32DataFrameColumn),
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<int>();
@@ -161,7 +229,7 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     ParquetColumn = new Column<int?>("nullable_int"),
-                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<int>),
+                    ExpectedColumnType = typeof(Int32DataFrameColumn),
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<int?>();
@@ -179,7 +247,7 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     ParquetColumn = new Column<long>("long"),
-                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<long>),
+                    ExpectedColumnType = typeof(Int64DataFrameColumn),
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<long>();
@@ -196,7 +264,7 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     ParquetColumn = new Column<long?>("nullable_long"),
-                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<long>),
+                    ExpectedColumnType = typeof(Int64DataFrameColumn),
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<long?>();
@@ -214,7 +282,7 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     ParquetColumn = new Column<float>("float"),
-                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<float>),
+                    ExpectedColumnType = typeof(SingleDataFrameColumn),
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<float>();
@@ -231,7 +299,7 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     ParquetColumn = new Column<float?>("nullable_float"),
-                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<float>),
+                    ExpectedColumnType = typeof(SingleDataFrameColumn),
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<float?>();
@@ -249,7 +317,7 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     ParquetColumn = new Column<double>("double"),
-                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<double>),
+                    ExpectedColumnType = typeof(DoubleDataFrameColumn),
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<double>();
@@ -266,7 +334,7 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     ParquetColumn = new Column<double?>("nullable_double"),
-                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<double>),
+                    ExpectedColumnType = typeof(DoubleDataFrameColumn),
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<double?>();

--- a/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
+++ b/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
@@ -477,6 +477,40 @@ namespace ParquetSharp.DataFrame.Test
                     },
                     NullCount = numRows => numRows / 10,
                 },
+                new TestColumn
+                {
+                    ParquetColumn = new Column<Date>("date"),
+                    ExpectedColumnType = typeof(Int32DataFrameColumn),
+                    WriteColumn = (numRows, columnWriter) =>
+                    {
+                        using var logicalWriter = columnWriter.LogicalWriter<Date>();
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => new Date(i)).ToArray());
+                    },
+                    VerifyColumn = column =>
+                    {
+                        for (int i = 0; i < column.Length; ++i)
+                        {
+                            Assert.Equal(i, column[i]);
+                        }
+                    }
+                },
+                new TestColumn
+                {
+                    ParquetColumn = new Column<Date?>("nullable_date"),
+                    ExpectedColumnType = typeof(Int32DataFrameColumn),
+                    WriteColumn = (numRows, columnWriter) =>
+                    {
+                        using var logicalWriter = columnWriter.LogicalWriter<Date?>();
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (Date?) new Date(i)).ToArray());
+                    },
+                    VerifyColumn = column =>
+                    {
+                        for (int i = 0; i < column.Length; ++i)
+                        {
+                            Assert.Equal(i, column[i]);
+                        }
+                    }
+                },
             };
         }
 

--- a/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
+++ b/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
@@ -17,9 +17,8 @@ namespace ParquetSharp.DataFrame.Test
             using var buffer = new ResizableBuffer();
             using (var output = new BufferOutputStream(buffer))
             {
-                var propertiesBuilder = new WriterPropertiesBuilder();
                 var columns = testColumns.Select(c => c.ParquetColumn).ToArray();
-                using var fileWriter = new ParquetFileWriter(output, columns, propertiesBuilder.Build());
+                using var fileWriter = new ParquetFileWriter(output, columns);
                 using var rowGroupWriter = fileWriter.AppendRowGroup();
 
                 foreach (var column in testColumns)

--- a/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
+++ b/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
@@ -239,7 +239,7 @@ namespace ParquetSharp.DataFrame.Test
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal(i % 10 == 0 ? (int?) null : i, column[i]);
+                            Assert.Equal(i % 10 == 0 ? null : (int?) i, column[i]);
                         }
                     },
                     NullCount = numRows => numRows / 10,
@@ -309,7 +309,7 @@ namespace ParquetSharp.DataFrame.Test
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal(i % 10 == 0 ? (float?) null : i, column[i]);
+                            Assert.Equal(i % 10 == 0 ? null : (float?) i, column[i]);
                         }
                     },
                     NullCount = numRows => numRows / 10,
@@ -344,7 +344,7 @@ namespace ParquetSharp.DataFrame.Test
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal(i % 10 == 0 ? (double?) null : i, column[i]);
+                            Assert.Equal(i % 10 == 0 ? null : (double?) i, column[i]);
                         }
                     },
                     NullCount = numRows => numRows / 10,
@@ -396,7 +396,7 @@ namespace ParquetSharp.DataFrame.Test
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal(i % 10 == 0 ? (bool?) null : (i % 2 == 0), column[i]);
+                            Assert.Equal(i % 10 == 0 ? null : (bool?) (i % 2 == 0), column[i]);
                         }
                     },
                     NullCount = numRows => numRows / 10,
@@ -435,7 +435,7 @@ namespace ParquetSharp.DataFrame.Test
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal(i % 10 == 0 ? (DateTime?) null : new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i), column[i]);
+                            Assert.Equal(i % 10 == 0 ? null : (DateTime?) new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i), column[i]);
                         }
                     },
                     NullCount = numRows => numRows / 10,
@@ -510,7 +510,7 @@ namespace ParquetSharp.DataFrame.Test
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal(i % 10 == 0 ? (decimal?) null : new decimal(i) / 100, column[i]);
+                            Assert.Equal(i % 10 == 0 ? null : (decimal?) new decimal(i) / 100, column[i]);
                         }
                     },
                     NullCount = numRows => numRows / 10,

--- a/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
+++ b/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
@@ -480,7 +480,7 @@ namespace ParquetSharp.DataFrame.Test
                 new TestColumn
                 {
                     ParquetColumn = new Column<Date>("date"),
-                    ExpectedColumnType = typeof(Int32DataFrameColumn),
+                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<Date>),
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<Date>();
@@ -490,14 +490,14 @@ namespace ParquetSharp.DataFrame.Test
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal(i, column[i]);
+                            Assert.Equal(new Date(i), column[i]);
                         }
                     }
                 },
                 new TestColumn
                 {
                     ParquetColumn = new Column<Date?>("nullable_date"),
-                    ExpectedColumnType = typeof(Int32DataFrameColumn),
+                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<Date>),
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<Date?>();
@@ -507,7 +507,7 @@ namespace ParquetSharp.DataFrame.Test
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal(i, column[i]);
+                            Assert.Equal(new Date(i), column[i]);
                         }
                     }
                 },

--- a/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
+++ b/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
@@ -73,7 +73,7 @@ namespace ParquetSharp.DataFrame.Test
                 fileWriter.Close();
             }
 
-            var columnNames = new[] {"int", "nullable_bool", "float"};
+            var columnNames = new[] { "int", "nullable_bool", "float" };
 
             using (var input = new BufferReader(buffer))
             {
@@ -117,7 +117,7 @@ namespace ParquetSharp.DataFrame.Test
                 fileWriter.Close();
             }
 
-            var columnNames = new[] {"does_not_exist"};
+            var columnNames = new[] { "does_not_exist" };
 
             using (var input = new BufferReader(buffer))
             {
@@ -131,15 +131,15 @@ namespace ParquetSharp.DataFrame.Test
         private readonly struct TestColumn
         {
             public Column ParquetColumn { get; init; }
-            public Type ExpectedColumnType { get; init;  }
-            public Action<int, ColumnWriter> WriteColumn { get; init;  }
-            public Action<DataFrameColumn> VerifyColumn { get; init;  }
+            public Type ExpectedColumnType { get; init; }
+            public Action<int, ColumnWriter> WriteColumn { get; init; }
+            public Action<DataFrameColumn> VerifyColumn { get; init; }
             public Func<long, long>? NullCount { get; init; }
         }
 
         private static TestColumn[] GetTestColumns()
         {
-            return new []
+            return new[]
             {
                 new TestColumn
                 {
@@ -148,13 +148,13 @@ namespace ParquetSharp.DataFrame.Test
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<byte>();
-                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (byte) (i % 256)).ToArray());
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (byte)(i % 256)).ToArray());
                     },
                     VerifyColumn = column =>
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal((byte) (i % 256), column[i]);
+                            Assert.Equal((byte)(i % 256), column[i]);
                         }
                     }
                 },
@@ -165,13 +165,13 @@ namespace ParquetSharp.DataFrame.Test
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<sbyte>();
-                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (sbyte) (i % 256 - 128)).ToArray());
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (sbyte)(i % 256 - 128)).ToArray());
                     },
                     VerifyColumn = column =>
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal((sbyte) (i % 256 - 128), column[i]);
+                            Assert.Equal((sbyte)(i % 256 - 128), column[i]);
                         }
                     }
                 },
@@ -182,13 +182,13 @@ namespace ParquetSharp.DataFrame.Test
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<ushort>();
-                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (ushort) (i % ushort.MaxValue)).ToArray());
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (ushort)(i % ushort.MaxValue)).ToArray());
                     },
                     VerifyColumn = column =>
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal((ushort) (i % ushort.MaxValue), column[i]);
+                            Assert.Equal((ushort)(i % ushort.MaxValue), column[i]);
                         }
                     }
                 },
@@ -199,13 +199,13 @@ namespace ParquetSharp.DataFrame.Test
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<short>();
-                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (short) (i % short.MaxValue)).ToArray());
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (short)(i % short.MaxValue)).ToArray());
                     },
                     VerifyColumn = column =>
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal((short) (i % short.MaxValue), column[i]);
+                            Assert.Equal((short)(i % short.MaxValue), column[i]);
                         }
                     }
                 },
@@ -233,13 +233,13 @@ namespace ParquetSharp.DataFrame.Test
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<int?>();
-                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (int?) null : i).ToArray());
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (int?)null : i).ToArray());
                     },
                     VerifyColumn = column =>
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal(i % 10 == 0 ? null : (int?) i, column[i]);
+                            Assert.Equal(i % 10 == 0 ? null : (int?)i, column[i]);
                         }
                     },
                     NullCount = numRows => numRows / 10,
@@ -251,13 +251,13 @@ namespace ParquetSharp.DataFrame.Test
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<long>();
-                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (long) i).ToArray());
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (long)i).ToArray());
                     },
                     VerifyColumn = column =>
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal((long) i, column[i]);
+                            Assert.Equal((long)i, column[i]);
                         }
                     }
                 },
@@ -268,13 +268,13 @@ namespace ParquetSharp.DataFrame.Test
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<long?>();
-                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (long?) null : i).ToArray());
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (long?)null : i).ToArray());
                     },
                     VerifyColumn = column =>
                     {
                         for (long i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal(i % 10 == 0 ? null : (long?) i, column[i]);
+                            Assert.Equal(i % 10 == 0 ? null : (long?)i, column[i]);
                         }
                     },
                     NullCount = numRows => numRows / 10,
@@ -286,13 +286,13 @@ namespace ParquetSharp.DataFrame.Test
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<float>();
-                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (float) i).ToArray());
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (float)i).ToArray());
                     },
                     VerifyColumn = column =>
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal((float) i, column[i]);
+                            Assert.Equal((float)i, column[i]);
                         }
                     }
                 },
@@ -303,13 +303,13 @@ namespace ParquetSharp.DataFrame.Test
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<float?>();
-                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (float?) null : i).ToArray());
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (float?)null : i).ToArray());
                     },
                     VerifyColumn = column =>
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal(i % 10 == 0 ? null : (float?) i, column[i]);
+                            Assert.Equal(i % 10 == 0 ? null : (float?)i, column[i]);
                         }
                     },
                     NullCount = numRows => numRows / 10,
@@ -321,13 +321,13 @@ namespace ParquetSharp.DataFrame.Test
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<double>();
-                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (double) i).ToArray());
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (double)i).ToArray());
                     },
                     VerifyColumn = column =>
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal((double) i, column[i]);
+                            Assert.Equal((double)i, column[i]);
                         }
                     }
                 },
@@ -338,13 +338,13 @@ namespace ParquetSharp.DataFrame.Test
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<double?>();
-                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (double?) null : i).ToArray());
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (double?)null : i).ToArray());
                     },
                     VerifyColumn = column =>
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal(i % 10 == 0 ? null : (double?) i, column[i]);
+                            Assert.Equal(i % 10 == 0 ? null : (double?)i, column[i]);
                         }
                     },
                     NullCount = numRows => numRows / 10,
@@ -390,13 +390,13 @@ namespace ParquetSharp.DataFrame.Test
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<bool?>();
-                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (bool?) null : (i % 2 == 0)).ToArray());
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (bool?)null : (i % 2 == 0)).ToArray());
                     },
                     VerifyColumn = column =>
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal(i % 10 == 0 ? null : (bool?) (i % 2 == 0), column[i]);
+                            Assert.Equal(i % 10 == 0 ? null : (bool?)(i % 2 == 0), column[i]);
                         }
                     },
                     NullCount = numRows => numRows / 10,
@@ -429,13 +429,13 @@ namespace ParquetSharp.DataFrame.Test
                         using var logicalWriter = columnWriter.LogicalWriter<DateTime?>();
                         logicalWriter.WriteBatch(
                             Enumerable.Range(0, numRows)
-                                .Select(i => i % 10 == 0 ? (DateTime?) null : new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i)).ToArray());
+                                .Select(i => i % 10 == 0 ? (DateTime?)null : new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i)).ToArray());
                     },
                     VerifyColumn = column =>
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal(i % 10 == 0 ? null : (DateTime?) new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i), column[i]);
+                            Assert.Equal(i % 10 == 0 ? null : (DateTime?)new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i), column[i]);
                         }
                     },
                     NullCount = numRows => numRows / 10,
@@ -468,7 +468,7 @@ namespace ParquetSharp.DataFrame.Test
                         using var logicalWriter = columnWriter.LogicalWriter<DateTimeNanos?>();
                         logicalWriter.WriteBatch(
                             Enumerable.Range(0, numRows)
-                                .Select(i => (DateTimeNanos?) new DateTimeNanos(i)).ToArray());
+                                .Select(i => (DateTimeNanos?)new DateTimeNanos(i)).ToArray());
                     },
                     VerifyColumn = column =>
                     {
@@ -486,7 +486,7 @@ namespace ParquetSharp.DataFrame.Test
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<decimal>();
                         logicalWriter.WriteBatch(Enumerable.Range(0, numRows)
-                                .Select(i => new decimal(i) / 100).ToArray());
+                            .Select(i => new decimal(i) / 100).ToArray());
                     },
                     VerifyColumn = column =>
                     {
@@ -504,13 +504,13 @@ namespace ParquetSharp.DataFrame.Test
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<decimal?>();
                         logicalWriter.WriteBatch(Enumerable.Range(0, numRows)
-                                .Select(i => i % 10 == 0 ? (decimal?) null : new decimal(i) / 100).ToArray());
+                            .Select(i => i % 10 == 0 ? (decimal?)null : new decimal(i) / 100).ToArray());
                     },
                     VerifyColumn = column =>
                     {
                         for (int i = 0; i < column.Length; ++i)
                         {
-                            Assert.Equal(i % 10 == 0 ? null : (decimal?) new decimal(i) / 100, column[i]);
+                            Assert.Equal(i % 10 == 0 ? null : (decimal?)new decimal(i) / 100, column[i]);
                         }
                     },
                     NullCount = numRows => numRows / 10,
@@ -539,7 +539,7 @@ namespace ParquetSharp.DataFrame.Test
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<Date?>();
-                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (Date?) new Date(i)).ToArray());
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (Date?)new Date(i)).ToArray());
                     },
                     VerifyColumn = column =>
                     {
@@ -590,7 +590,7 @@ namespace ParquetSharp.DataFrame.Test
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<TimeSpan?>();
-                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (TimeSpan?) TimeSpan.FromMilliseconds(i)).ToArray());
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (TimeSpan?)TimeSpan.FromMilliseconds(i)).ToArray());
                     },
                     VerifyColumn = column =>
                     {
@@ -624,7 +624,7 @@ namespace ParquetSharp.DataFrame.Test
                     WriteColumn = (numRows, columnWriter) =>
                     {
                         using var logicalWriter = columnWriter.LogicalWriter<TimeSpanNanos?>();
-                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (TimeSpanNanos?) new TimeSpanNanos(i)).ToArray());
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (TimeSpanNanos?)new TimeSpanNanos(i)).ToArray());
                     },
                     VerifyColumn = column =>
                     {
@@ -636,6 +636,5 @@ namespace ParquetSharp.DataFrame.Test
                 },
             };
         }
-
     }
 }

--- a/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
+++ b/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
@@ -20,7 +20,13 @@ namespace ParquetSharp.DataFrame.Test
                 new Column<DateTime>("dateTime"),
             };
 
-            const int numRows = 1000;
+            const int numRows = 10_000;
+            var intData = Enumerable.Range(0, numRows).ToArray();
+            var doubleData = Enumerable.Range(0, numRows).Select(i => (double) i).ToArray();
+            var stringData = Enumerable.Range(0, numRows).Select(i => i.ToString()).ToArray();
+            var boolData = Enumerable.Range(0, numRows).Select(i => i % 2 == 0).ToArray();
+            var dateTimeData = Enumerable.Range(0, numRows)
+                .Select(i => new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i)).ToArray();
 
             using var buffer = new ResizableBuffer();
             using (var output = new BufferOutputStream(buffer))
@@ -30,21 +36,19 @@ namespace ParquetSharp.DataFrame.Test
                 using var rowGroupWriter = fileWriter.AppendRowGroup();
 
                 using var intCol = rowGroupWriter.NextColumn().LogicalWriter<int>();
-                intCol.WriteBatch(Enumerable.Range(0, numRows).ToArray());
+                intCol.WriteBatch(intData);
 
                 using var doubleCol = rowGroupWriter.NextColumn().LogicalWriter<double>();
-                doubleCol.WriteBatch(Enumerable.Range(0, numRows).Select(i => (double) i).ToArray());
+                doubleCol.WriteBatch(doubleData);
 
                 using var stringCol = rowGroupWriter.NextColumn().LogicalWriter<string>();
-                stringCol.WriteBatch(Enumerable.Range(0, numRows).Select(i => i.ToString()).ToArray());
+                stringCol.WriteBatch(stringData);
 
                 using var boolCol = rowGroupWriter.NextColumn().LogicalWriter<bool>();
-                boolCol.WriteBatch(Enumerable.Range(0, numRows).Select(i => i % 2 == 0).ToArray());
+                boolCol.WriteBatch(boolData);
 
                 using var dateTimeCol = rowGroupWriter.NextColumn().LogicalWriter<DateTime>();
-                dateTimeCol.WriteBatch(
-                    Enumerable.Range(0, numRows)
-                        .Select(i => new DateTime(2021, 12, 8) + TimeSpan.FromSeconds(i)).ToArray());
+                dateTimeCol.WriteBatch(dateTimeData);
 
                 fileWriter.Close();
             }
@@ -58,18 +62,48 @@ namespace ParquetSharp.DataFrame.Test
 
                 var intCol = dataFrame["int"];
                 Assert.IsType<PrimitiveDataFrameColumn<int>>(intCol);
+                Assert.Equal(numRows, intCol.Length);
+                Assert.Equal(0, intCol.NullCount);
+                for (int i = 0; i < numRows; ++i)
+                {
+                    Assert.Equal(intCol[i], intData[i]);
+                }
 
                 var doubleCol = dataFrame["double"];
                 Assert.IsType<PrimitiveDataFrameColumn<double>>(doubleCol);
+                Assert.Equal(numRows, doubleCol.Length);
+                Assert.Equal(0, doubleCol.NullCount);
+                for (int i = 0; i < numRows; ++i)
+                {
+                    Assert.Equal(doubleData[i], doubleCol[i]);
+                }
 
                 var stringCol = dataFrame["string"];
                 Assert.IsType<StringDataFrameColumn>(stringCol);
+                Assert.Equal(numRows, stringCol.Length);
+                Assert.Equal(0, stringCol.NullCount);
+                for (int i = 0; i < numRows; ++i)
+                {
+                    Assert.Equal(stringData[i], stringCol[i]);
+                }
 
                 var boolCol = dataFrame["bool"];
                 Assert.IsType<BooleanDataFrameColumn>(boolCol);
+                Assert.Equal(numRows, boolCol.Length);
+                Assert.Equal(0, boolCol.NullCount);
+                for (int i = 0; i < numRows; ++i)
+                {
+                    Assert.Equal(boolData[i], boolCol[i]);
+                }
 
                 var dateTimeCol = dataFrame["dateTime"];
                 Assert.IsType<PrimitiveDataFrameColumn<DateTime>>(dateTimeCol);
+                Assert.Equal(numRows, dateTimeCol.Length);
+                Assert.Equal(0, dateTimeCol.NullCount);
+                for (int i = 0; i < numRows; ++i)
+                {
+                    Assert.Equal(dateTimeData[i], dateTimeCol[i]);
+                }
 
                 fileReader.Close();
             }

--- a/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
+++ b/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
@@ -128,7 +128,7 @@ namespace ParquetSharp.DataFrame.Test
             }
         }
 
-        private readonly struct TestColumn
+        private struct TestColumn
         {
             public Column ParquetColumn { get; init; }
             public Type ExpectedColumnType { get; init; }

--- a/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
+++ b/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
@@ -100,6 +100,76 @@ namespace ParquetSharp.DataFrame.Test
                 },
                 new TestColumn
                 {
+                    ParquetColumn = new Column<long>("long"),
+                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<long>),
+                    WriteColumn = (numRows, columnWriter) =>
+                    {
+                        using var logicalWriter = columnWriter.LogicalWriter<long>();
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (long) i).ToArray());
+                    },
+                    VerifyColumn = column =>
+                    {
+                        for (int i = 0; i < column.Length; ++i)
+                        {
+                            Assert.Equal((long) i, column[i]);
+                        }
+                    }
+                },
+                new TestColumn
+                {
+                    ParquetColumn = new Column<long?>("nullable_long"),
+                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<long>),
+                    WriteColumn = (numRows, columnWriter) =>
+                    {
+                        using var logicalWriter = columnWriter.LogicalWriter<long?>();
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (long?) null : i).ToArray());
+                    },
+                    VerifyColumn = column =>
+                    {
+                        for (long i = 0; i < column.Length; ++i)
+                        {
+                            Assert.Equal(i % 10 == 0 ? null : i, column[i]);
+                        }
+                    },
+                    NullCount = numRows => numRows / 10,
+                },
+                new TestColumn
+                {
+                    ParquetColumn = new Column<float>("float"),
+                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<float>),
+                    WriteColumn = (numRows, columnWriter) =>
+                    {
+                        using var logicalWriter = columnWriter.LogicalWriter<float>();
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (float) i).ToArray());
+                    },
+                    VerifyColumn = column =>
+                    {
+                        for (int i = 0; i < column.Length; ++i)
+                        {
+                            Assert.Equal((float) i, column[i]);
+                        }
+                    }
+                },
+                new TestColumn
+                {
+                    ParquetColumn = new Column<float?>("nullable_float"),
+                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<float>),
+                    WriteColumn = (numRows, columnWriter) =>
+                    {
+                        using var logicalWriter = columnWriter.LogicalWriter<float?>();
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => i % 10 == 0 ? (float?) null : i).ToArray());
+                    },
+                    VerifyColumn = column =>
+                    {
+                        for (int i = 0; i < column.Length; ++i)
+                        {
+                            Assert.Equal(i % 10 == 0 ? (float?) null : i, column[i]);
+                        }
+                    },
+                    NullCount = numRows => numRows / 10,
+                },
+                new TestColumn
+                {
                     ParquetColumn = new Column<double>("double"),
                     ExpectedColumnType = typeof(PrimitiveDataFrameColumn<double>),
                     WriteColumn = (numRows, columnWriter) =>

--- a/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
+++ b/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+using ParquetSharp.IO;
+using Xunit;
+
+namespace ParquetSharp.DataFrame.Test
+{
+    public class ParquetToDataFrame
+    {
+        [Fact]
+        public void TestToDataFrame()
+        {
+            var columns = new Column[]
+            {
+                new Column<int>("int"),
+                new Column<double>("double"),
+                new Column<string>("string"),
+                new Column<bool>("bool")
+            };
+
+            const int numRows = 1000;
+                
+            using var buffer = new ResizableBuffer();
+            using (var output = new BufferOutputStream(buffer))
+            {
+                var propertiesBuilder = new WriterPropertiesBuilder();
+                using var fileWriter = new ParquetFileWriter(output, columns, propertiesBuilder.Build());
+                using var rowGroupWriter = fileWriter.AppendRowGroup();
+                
+                using var intCol = rowGroupWriter.NextColumn().LogicalWriter<int>();
+                intCol.WriteBatch(Enumerable.Range(0, numRows).ToArray());
+                
+                using var doubleCol = rowGroupWriter.NextColumn().LogicalWriter<double>();
+                doubleCol.WriteBatch(Enumerable.Range(0, numRows).Select(i => (double) i).ToArray());
+                
+                using var stringCol = rowGroupWriter.NextColumn().LogicalWriter<string>();
+                stringCol.WriteBatch(Enumerable.Range(0, numRows).Select(i => i.ToString()).ToArray());
+                
+                using var boolCol = rowGroupWriter.NextColumn().LogicalWriter<bool>();
+                boolCol.WriteBatch(Enumerable.Range(0, numRows).Select(i => i % 2 == 0).ToArray());
+
+                fileWriter.Close();
+            }
+
+            using (var input = new BufferReader(buffer))
+            {
+                using var fileReader = new ParquetFileReader(input);
+                var dataFrame = fileReader.ToDataFrame();
+                
+                Assert.Equal(4, dataFrame.Columns.Count);
+                    
+                fileReader.Close();
+            }
+        }
+    }
+}

--- a/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
+++ b/ParquetSharp.DataFrame.Test/ParquetToDataFrame.cs
@@ -511,6 +511,57 @@ namespace ParquetSharp.DataFrame.Test
                         }
                     }
                 },
+                new TestColumn
+                {
+                    ParquetColumn = new Column<TimeSpan>("time_ms", LogicalType.Time(isAdjustedToUtc: true, TimeUnit.Millis)),
+                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<TimeSpan>),
+                    WriteColumn = (numRows, columnWriter) =>
+                    {
+                        using var logicalWriter = columnWriter.LogicalWriter<TimeSpan>();
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => TimeSpan.FromMilliseconds(i)).ToArray());
+                    },
+                    VerifyColumn = column =>
+                    {
+                        for (int i = 0; i < column.Length; ++i)
+                        {
+                            Assert.Equal(TimeSpan.FromMilliseconds(i), column[i]);
+                        }
+                    }
+                },
+                new TestColumn
+                {
+                    ParquetColumn = new Column<TimeSpan>("time_us", LogicalType.Time(isAdjustedToUtc: true, TimeUnit.Micros)),
+                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<TimeSpan>),
+                    WriteColumn = (numRows, columnWriter) =>
+                    {
+                        using var logicalWriter = columnWriter.LogicalWriter<TimeSpan>();
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => TimeSpan.FromMilliseconds(i)).ToArray());
+                    },
+                    VerifyColumn = column =>
+                    {
+                        for (int i = 0; i < column.Length; ++i)
+                        {
+                            Assert.Equal(TimeSpan.FromMilliseconds(i), column[i]);
+                        }
+                    }
+                },
+                new TestColumn
+                {
+                    ParquetColumn = new Column<TimeSpan?>("nullable_time_us", LogicalType.Time(isAdjustedToUtc: true, TimeUnit.Micros)),
+                    ExpectedColumnType = typeof(PrimitiveDataFrameColumn<TimeSpan>),
+                    WriteColumn = (numRows, columnWriter) =>
+                    {
+                        using var logicalWriter = columnWriter.LogicalWriter<TimeSpan?>();
+                        logicalWriter.WriteBatch(Enumerable.Range(0, numRows).Select(i => (TimeSpan?) TimeSpan.FromMilliseconds(i)).ToArray());
+                    },
+                    VerifyColumn = column =>
+                    {
+                        for (int i = 0; i < column.Length; ++i)
+                        {
+                            Assert.Equal(TimeSpan.FromMilliseconds(i), column[i]);
+                        }
+                    }
+                },
             };
         }
 

--- a/ParquetSharp.DataFrame.Test/UnitTestDisposableDirectory.cs
+++ b/ParquetSharp.DataFrame.Test/UnitTestDisposableDirectory.cs
@@ -1,0 +1,22 @@
+using System;
+using System.IO;
+
+namespace ParquetSharp.DataFrame.Test
+{
+    internal sealed class UnitTestDisposableDirectory : IDisposable
+    {
+        public UnitTestDisposableDirectory()
+        {
+            var path = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
+            Info = new DirectoryInfo(path);
+            Info.Create();
+        }
+
+        public DirectoryInfo Info { get; }
+
+        public void Dispose()
+        {
+            Info.Delete(true);
+        }
+    }
+}

--- a/ParquetSharp.DataFrame.Test/UnitTestDisposableDirectory.cs
+++ b/ParquetSharp.DataFrame.Test/UnitTestDisposableDirectory.cs
@@ -7,7 +7,7 @@ namespace ParquetSharp.DataFrame.Test
     {
         public UnitTestDisposableDirectory()
         {
-            var path = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
+            var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Info = new DirectoryInfo(path);
             Info.Create();
         }

--- a/ParquetSharp.DataFrame.sln
+++ b/ParquetSharp.DataFrame.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.6.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParquetSharp.DataFrame", "ParquetSharp.DataFrame\ParquetSharp.DataFrame.csproj", "{E976DBA7-43C8-4420-84A0-0ACA5C8B433F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParquetSharp.DataFrame.Test", "ParquetSharp.DataFrame.Test\ParquetSharp.DataFrame.Test.csproj", "{148E23F2-2E8C-4B62-8BF3-F105FC9200FF}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E976DBA7-43C8-4420-84A0-0ACA5C8B433F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E976DBA7-43C8-4420-84A0-0ACA5C8B433F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E976DBA7-43C8-4420-84A0-0ACA5C8B433F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E976DBA7-43C8-4420-84A0-0ACA5C8B433F}.Debug|x64.Build.0 = Debug|Any CPU
+		{E976DBA7-43C8-4420-84A0-0ACA5C8B433F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E976DBA7-43C8-4420-84A0-0ACA5C8B433F}.Debug|x86.Build.0 = Debug|Any CPU
+		{E976DBA7-43C8-4420-84A0-0ACA5C8B433F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E976DBA7-43C8-4420-84A0-0ACA5C8B433F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E976DBA7-43C8-4420-84A0-0ACA5C8B433F}.Release|x64.ActiveCfg = Release|Any CPU
+		{E976DBA7-43C8-4420-84A0-0ACA5C8B433F}.Release|x64.Build.0 = Release|Any CPU
+		{E976DBA7-43C8-4420-84A0-0ACA5C8B433F}.Release|x86.ActiveCfg = Release|Any CPU
+		{E976DBA7-43C8-4420-84A0-0ACA5C8B433F}.Release|x86.Build.0 = Release|Any CPU
+		{148E23F2-2E8C-4B62-8BF3-F105FC9200FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{148E23F2-2E8C-4B62-8BF3-F105FC9200FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{148E23F2-2E8C-4B62-8BF3-F105FC9200FF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{148E23F2-2E8C-4B62-8BF3-F105FC9200FF}.Debug|x64.Build.0 = Debug|Any CPU
+		{148E23F2-2E8C-4B62-8BF3-F105FC9200FF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{148E23F2-2E8C-4B62-8BF3-F105FC9200FF}.Debug|x86.Build.0 = Debug|Any CPU
+		{148E23F2-2E8C-4B62-8BF3-F105FC9200FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{148E23F2-2E8C-4B62-8BF3-F105FC9200FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{148E23F2-2E8C-4B62-8BF3-F105FC9200FF}.Release|x64.ActiveCfg = Release|Any CPU
+		{148E23F2-2E8C-4B62-8BF3-F105FC9200FF}.Release|x64.Build.0 = Release|Any CPU
+		{148E23F2-2E8C-4B62-8BF3-F105FC9200FF}.Release|x86.ActiveCfg = Release|Any CPU
+		{148E23F2-2E8C-4B62-8BF3-F105FC9200FF}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/ParquetSharp.DataFrame/.editorconfig
+++ b/ParquetSharp.DataFrame/.editorconfig
@@ -1,0 +1,39 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.csproj]
+indent_size = 2
+resharper_xml_wrap_tags_and_pi = false
+
+[*.cs]
+csharp_new_line_before_members_in_object_initializers = false
+csharp_preserve_single_line_blocks = true
+resharper_blank_lines_after_block_statements = 0
+resharper_blank_lines_around_auto_property = 0
+resharper_blank_lines_around_single_line_type = 0
+resharper_csharp_blank_lines_around_field = 0
+resharper_csharp_insert_final_newline = true
+resharper_csharp_wrap_lines = false
+resharper_empty_block_style = multiline
+resharper_keep_existing_embedded_block_arrangement = false
+resharper_keep_existing_enum_arrangement = false
+resharper_max_attribute_length_for_same_line = 70
+resharper_place_accessorholder_attribute_on_same_line = false
+resharper_place_expr_accessor_on_single_line = true
+resharper_place_expr_method_on_single_line = true
+resharper_place_expr_property_on_single_line = true
+resharper_place_field_attribute_on_same_line = false
+resharper_place_simple_embedded_statement_on_same_line = true
+resharper_place_simple_initializer_on_single_line = false
+resharper_remove_blank_lines_near_braces_in_code = false
+resharper_remove_blank_lines_near_braces_in_declarations = false
+resharper_wrap_array_initializer_style = chop_if_long
+resharper_wrap_chained_binary_expressions = chop_if_long
+resharper_wrap_object_and_collection_initializer_style = chop_always

--- a/ParquetSharp.DataFrame/ColumnCreator.cs
+++ b/ParquetSharp.DataFrame/ColumnCreator.cs
@@ -38,8 +38,8 @@ namespace ParquetSharp.DataFrame
                 case LogicalColumnReader<DateTime>:
                 case LogicalColumnReader<DateTime?>:
                     return new PrimitiveDataFrameColumn<DateTime>(_columnName, _numRows);
-                case LogicalColumnReader<Decimal>:
-                case LogicalColumnReader<Decimal?>:
+                case LogicalColumnReader<decimal>:
+                case LogicalColumnReader<decimal?>:
                     return new DecimalDataFrameColumn(_columnName, _numRows);
                 default:
                     throw new NotImplementedException($"Unsupported column logical type: {typeof(TElement)}");

--- a/ParquetSharp.DataFrame/ColumnCreator.cs
+++ b/ParquetSharp.DataFrame/ColumnCreator.cs
@@ -22,6 +22,11 @@ namespace ParquetSharp
 
         public DataFrameColumn OnLogicalColumnReader<TElement>(LogicalColumnReader<TElement> columnReader)
         {
+            if (columnReader.ColumnDescriptor.LogicalType is IntLogicalType intType)
+            {
+                return ColumnFromIntType(intType);
+            }
+
             switch (columnReader)
             {
                 case LogicalColumnReader<string>:
@@ -29,18 +34,36 @@ namespace ParquetSharp
                 case LogicalColumnReader<bool>:
                 case LogicalColumnReader<bool?>:
                     return new BooleanDataFrameColumn(_columnName, _numRows);
+                case LogicalColumnReader<byte>:
+                case LogicalColumnReader<byte?>:
+                    return new ByteDataFrameColumn(_columnName, _numRows);
+                case LogicalColumnReader<sbyte>:
+                case LogicalColumnReader<sbyte?>:
+                    return new SByteDataFrameColumn(_columnName, _numRows);
+                case LogicalColumnReader<ushort>:
+                case LogicalColumnReader<ushort?>:
+                    return new UInt16DataFrameColumn(_columnName, _numRows);
+                case LogicalColumnReader<short>:
+                case LogicalColumnReader<short?>:
+                    return new Int16DataFrameColumn(_columnName, _numRows);
+                case LogicalColumnReader<uint>:
+                case LogicalColumnReader<uint?>:
+                    return new UInt32DataFrameColumn(_columnName, _numRows);
                 case LogicalColumnReader<int>:
                 case LogicalColumnReader<int?>:
-                    return new PrimitiveDataFrameColumn<int>(_columnName, _numRows);
+                    return new Int32DataFrameColumn(_columnName, _numRows);
+                case LogicalColumnReader<ulong>:
+                case LogicalColumnReader<ulong?>:
+                    return new UInt64DataFrameColumn(_columnName, _numRows);
                 case LogicalColumnReader<long>:
                 case LogicalColumnReader<long?>:
-                    return new PrimitiveDataFrameColumn<long>(_columnName, _numRows);
+                    return new Int64DataFrameColumn(_columnName, _numRows);
                 case LogicalColumnReader<float>:
                 case LogicalColumnReader<float?>:
-                    return new PrimitiveDataFrameColumn<float>(_columnName, _numRows);
+                    return new SingleDataFrameColumn(_columnName, _numRows);
                 case LogicalColumnReader<double>:
                 case LogicalColumnReader<double?>:
-                    return new PrimitiveDataFrameColumn<double>(_columnName, _numRows);
+                    return new DoubleDataFrameColumn(_columnName, _numRows);
                 case LogicalColumnReader<DateTime>:
                 case LogicalColumnReader<DateTime?>:
                     return new PrimitiveDataFrameColumn<DateTime>(_columnName, _numRows);
@@ -50,6 +73,21 @@ namespace ParquetSharp
                 default:
                     throw new NotImplementedException($"Unsupported column logical type: {typeof(TElement)}");
             }
+        }
+
+        private DataFrameColumn ColumnFromIntType(IntLogicalType intType)
+        {
+            return (intType.BitWidth, intType.IsSigned) switch
+            {
+                (8, false) => new ByteDataFrameColumn(_columnName, _numRows),
+                (8, true) => new SByteDataFrameColumn(_columnName, _numRows),
+                (16, false) => new UInt16DataFrameColumn(_columnName, _numRows),
+                (16, true) => new Int16DataFrameColumn(_columnName, _numRows),
+                (32, false) => new UInt32DataFrameColumn(_columnName, _numRows),
+                (32, true) => new Int32DataFrameColumn(_columnName, _numRows),
+                (_, false) => new UInt64DataFrameColumn(_columnName, _numRows),
+                (_, true) => new Int64DataFrameColumn(_columnName, _numRows)
+            };
         }
 
         private readonly string _columnName;

--- a/ParquetSharp.DataFrame/ColumnCreator.cs
+++ b/ParquetSharp.DataFrame/ColumnCreator.cs
@@ -70,6 +70,9 @@ namespace ParquetSharp
                 case LogicalColumnReader<decimal>:
                 case LogicalColumnReader<decimal?>:
                     return new DecimalDataFrameColumn(_columnName, _numRows);
+                case LogicalColumnReader<Date>:
+                case LogicalColumnReader<Date?>:
+                    return new Int32DataFrameColumn(_columnName, _numRows);
                 default:
                     throw new NotImplementedException($"Unsupported column logical type: {typeof(TElement)}");
             }

--- a/ParquetSharp.DataFrame/ColumnCreator.cs
+++ b/ParquetSharp.DataFrame/ColumnCreator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using Microsoft.Data.Analysis;
 
 namespace ParquetSharp
@@ -73,6 +74,9 @@ namespace ParquetSharp
                 case LogicalColumnReader<Date>:
                 case LogicalColumnReader<Date?>:
                     return new Int32DataFrameColumn(_columnName, _numRows);
+                case LogicalColumnReader<TimeSpan>:
+                case LogicalColumnReader<TimeSpan?>:
+                    return new PrimitiveDataFrameColumn<TimeSpan>(_columnName, _numRows);
                 default:
                     throw new NotImplementedException($"Unsupported column logical type: {typeof(TElement)}");
             }

--- a/ParquetSharp.DataFrame/ColumnCreator.cs
+++ b/ParquetSharp.DataFrame/ColumnCreator.cs
@@ -4,10 +4,16 @@ using Microsoft.Data.Analysis;
 namespace ParquetSharp
 {
     /// <summary>
-    /// LogicalColumnReaderVisitor that creates DataFrameColumns
+    /// LogicalColumnReaderVisitor that creates DataFrameColumns of the correct type,
+    /// corresponding to the Parquet LogicalColumnReader type.
     /// </summary>
     internal sealed class ColumnCreator : ILogicalColumnReaderVisitor<DataFrameColumn>
     {
+        /// <summary>
+        /// Create a ColumnCreator
+        /// </summary>
+        /// <param name="columnName">Name of the column to create</param>
+        /// <param name="numRows">Total number of rows in the column</param>
         public ColumnCreator(string columnName, long numRows)
         {
             _columnName = columnName;

--- a/ParquetSharp.DataFrame/ColumnCreator.cs
+++ b/ParquetSharp.DataFrame/ColumnCreator.cs
@@ -73,7 +73,7 @@ namespace ParquetSharp
                     return new DecimalDataFrameColumn(_columnName, _numRows);
                 case LogicalColumnReader<Date>:
                 case LogicalColumnReader<Date?>:
-                    return new Int32DataFrameColumn(_columnName, _numRows);
+                    return new PrimitiveDataFrameColumn<Date>(_columnName, _numRows);
                 case LogicalColumnReader<TimeSpan>:
                 case LogicalColumnReader<TimeSpan?>:
                     return new PrimitiveDataFrameColumn<TimeSpan>(_columnName, _numRows);

--- a/ParquetSharp.DataFrame/ColumnCreator.cs
+++ b/ParquetSharp.DataFrame/ColumnCreator.cs
@@ -1,7 +1,7 @@
 using System;
 using Microsoft.Data.Analysis;
 
-namespace ParquetSharp.DataFrame
+namespace ParquetSharp
 {
     /// <summary>
     /// LogicalColumnReaderVisitor that creates DataFrameColumns

--- a/ParquetSharp.DataFrame/ColumnCreator.cs
+++ b/ParquetSharp.DataFrame/ColumnCreator.cs
@@ -68,6 +68,9 @@ namespace ParquetSharp
                 case LogicalColumnReader<DateTime>:
                 case LogicalColumnReader<DateTime?>:
                     return new PrimitiveDataFrameColumn<DateTime>(_columnName, _numRows);
+                case LogicalColumnReader<DateTimeNanos>:
+                case LogicalColumnReader<DateTimeNanos?>:
+                    return new PrimitiveDataFrameColumn<DateTimeNanos>(_columnName, _numRows);
                 case LogicalColumnReader<decimal>:
                 case LogicalColumnReader<decimal?>:
                     return new DecimalDataFrameColumn(_columnName, _numRows);
@@ -77,6 +80,9 @@ namespace ParquetSharp
                 case LogicalColumnReader<TimeSpan>:
                 case LogicalColumnReader<TimeSpan?>:
                     return new PrimitiveDataFrameColumn<TimeSpan>(_columnName, _numRows);
+                case LogicalColumnReader<TimeSpanNanos>:
+                case LogicalColumnReader<TimeSpanNanos?>:
+                    return new PrimitiveDataFrameColumn<TimeSpanNanos>(_columnName, _numRows);
                 default:
                     throw new NotImplementedException($"Unsupported column logical type: {typeof(TElement)}");
             }

--- a/ParquetSharp.DataFrame/ColumnCreator.cs
+++ b/ParquetSharp.DataFrame/ColumnCreator.cs
@@ -1,0 +1,52 @@
+using System;
+using Microsoft.Data.Analysis;
+
+namespace ParquetSharp.DataFrame
+{
+    /// <summary>
+    /// LogicalColumnReaderVisitor that creates DataFrameColumns
+    /// </summary>
+    internal sealed class ColumnCreator : ILogicalColumnReaderVisitor<DataFrameColumn>
+    {
+        public ColumnCreator(string columnName, long numRows)
+        {
+            _columnName = columnName;
+            _numRows = numRows;
+        }
+
+        public DataFrameColumn OnLogicalColumnReader<TElement>(LogicalColumnReader<TElement> columnReader)
+        {
+            switch (columnReader)
+            {
+                case LogicalColumnReader<string>:
+                    return new StringDataFrameColumn(_columnName, _numRows);
+                case LogicalColumnReader<bool>:
+                case LogicalColumnReader<bool?>:
+                    return new BooleanDataFrameColumn(_columnName, _numRows);
+                case LogicalColumnReader<int>:
+                case LogicalColumnReader<int?>:
+                    return new PrimitiveDataFrameColumn<int>(_columnName, _numRows);
+                case LogicalColumnReader<long>:
+                case LogicalColumnReader<long?>:
+                    return new PrimitiveDataFrameColumn<long>(_columnName, _numRows);
+                case LogicalColumnReader<float>:
+                case LogicalColumnReader<float?>:
+                    return new PrimitiveDataFrameColumn<float>(_columnName, _numRows);
+                case LogicalColumnReader<double>:
+                case LogicalColumnReader<double?>:
+                    return new PrimitiveDataFrameColumn<double>(_columnName, _numRows);
+                case LogicalColumnReader<DateTime>:
+                case LogicalColumnReader<DateTime?>:
+                    return new PrimitiveDataFrameColumn<DateTime>(_columnName, _numRows);
+                case LogicalColumnReader<Decimal>:
+                case LogicalColumnReader<Decimal?>:
+                    return new DecimalDataFrameColumn(_columnName, _numRows);
+                default:
+                    throw new NotImplementedException($"Unsupported column logical type: {typeof(TElement)}");
+            }
+        }
+
+        private readonly string _columnName;
+        private readonly long _numRows;
+    }
+}

--- a/ParquetSharp.DataFrame/DataFrameExtensions.cs
+++ b/ParquetSharp.DataFrame/DataFrameExtensions.cs
@@ -6,12 +6,12 @@ namespace ParquetSharp
 {
     public static class DataFrameExtensions
     {
-        public static void ToParquet(this DataFrame dataFrame, string path)
+        public static void ToParquet(this DataFrame dataFrame, string path, WriterProperties writerProperties = null)
         {
-            var propertiesBuilder = new WriterPropertiesBuilder();
-            using var writerProperties = propertiesBuilder.Build();
             var schemaColumns = dataFrame.Columns.Select(GetSchemaColumn).ToArray();
-            using var fileWriter = new ParquetFileWriter(path, schemaColumns, writerProperties);
+            using var fileWriter = writerProperties == null
+                ? new ParquetFileWriter(path, schemaColumns)
+                : new ParquetFileWriter(path, schemaColumns, writerProperties);
 
             const int rowGroupSize = 1024 * 1024;
             var numRows = dataFrame.Rows.Count;

--- a/ParquetSharp.DataFrame/DataFrameExtensions.cs
+++ b/ParquetSharp.DataFrame/DataFrameExtensions.cs
@@ -16,9 +16,10 @@ namespace ParquetSharp
         /// <param name="logicalTypeOverrides">Mapping from column names to Parquet logical types,
         /// overriding the default logical types. When writing decimal columns, a logical type must be provided
         /// to specify the precision and scale to use.</param>
+        /// <param name="rowGroupSize">Maximum number of rows per row group</param>
         public static void ToParquet(
             this DataFrame dataFrame, string path, WriterProperties? writerProperties = null,
-            IReadOnlyDictionary<string, LogicalType>? logicalTypeOverrides = null)
+            IReadOnlyDictionary<string, LogicalType>? logicalTypeOverrides = null, int rowGroupSize = 1024 * 1024)
         {
             var schemaColumns = dataFrame.Columns.Select(col => GetSchemaColumn(
                 col, logicalTypeOverrides != null && logicalTypeOverrides.TryGetValue(col.Name, out var logicalType) ? logicalType : null)).ToArray();
@@ -26,7 +27,6 @@ namespace ParquetSharp
                 ? new ParquetFileWriter(path, schemaColumns)
                 : new ParquetFileWriter(path, schemaColumns, writerProperties);
 
-            const int rowGroupSize = 1024 * 1024;
             var numRows = dataFrame.Rows.Count;
             var offset = 0L;
 

--- a/ParquetSharp.DataFrame/DataFrameExtensions.cs
+++ b/ParquetSharp.DataFrame/DataFrameExtensions.cs
@@ -8,8 +8,8 @@ namespace ParquetSharp
     public static class DataFrameExtensions
     {
         public static void ToParquet(
-            this DataFrame dataFrame, string path, WriterProperties writerProperties = null,
-            IReadOnlyDictionary<string, LogicalType> logicalTypeOverrides = null)
+            this DataFrame dataFrame, string path, WriterProperties? writerProperties = null,
+            IReadOnlyDictionary<string, LogicalType>? logicalTypeOverrides = null)
         {
             var schemaColumns = dataFrame.Columns.Select(col => GetSchemaColumn(
                 col, logicalTypeOverrides != null && logicalTypeOverrides.TryGetValue(col.Name, out var logicalType) ? logicalType : null)).ToArray();
@@ -37,7 +37,7 @@ namespace ParquetSharp
             fileWriter.Close();
         }
 
-        private static Column GetSchemaColumn(DataFrameColumn column, LogicalType logicalTypeOverride)
+        private static Column GetSchemaColumn(DataFrameColumn column, LogicalType? logicalTypeOverride)
         {
             var dataType = column.DataType;
             var nullable = column.NullCount > 0;

--- a/ParquetSharp.DataFrame/DataFrameExtensions.cs
+++ b/ParquetSharp.DataFrame/DataFrameExtensions.cs
@@ -7,6 +7,15 @@ namespace ParquetSharp
 {
     public static class DataFrameExtensions
     {
+        /// <summary>
+        /// Write a DataFrame in Parquet format
+        /// </summary>
+        /// <param name="dataFrame">The DataFrame to write</param>
+        /// <param name="path">Path to write to</param>
+        /// <param name="writerProperties">Optional writer properties that override the default properties</param>
+        /// <param name="logicalTypeOverrides">Mapping from column names to Parquet logical types,
+        /// overriding the default logical types. When writing decimal columns, a logical type must be provided
+        /// to specify the precision and scale to use.</param>
         public static void ToParquet(
             this DataFrame dataFrame, string path, WriterProperties? writerProperties = null,
             IReadOnlyDictionary<string, LogicalType>? logicalTypeOverrides = null)

--- a/ParquetSharp.DataFrame/DataFrameExtensions.cs
+++ b/ParquetSharp.DataFrame/DataFrameExtensions.cs
@@ -32,7 +32,7 @@ namespace ParquetSharp
 
             while (offset < numRows)
             {
-                var batchSize = (int) Math.Min(numRows - offset, rowGroupSize);
+                var batchSize = (int)Math.Min(numRows - offset, rowGroupSize);
                 using var rowGroupWriter = fileWriter.AppendRowGroup();
                 foreach (var dataFrameColumn in dataFrame.Columns)
                 {
@@ -40,6 +40,7 @@ namespace ParquetSharp
                     using var logicalWriter = columnWriter.LogicalWriter();
                     logicalWriter.Apply(new DataFrameWriter(dataFrameColumn, offset, batchSize));
                 }
+
                 offset += batchSize;
             }
 
@@ -54,10 +55,12 @@ namespace ParquetSharp
             {
                 throw new ArgumentException($"Logical type override must be specified for decimal column '{column.Name}'");
             }
+
             if (nullable && dataType.IsValueType)
             {
                 dataType = typeof(Nullable<>).MakeGenericType(dataType);
             }
+
             return new Column(dataType, column.Name, logicalTypeOverride);
         }
     }

--- a/ParquetSharp.DataFrame/DataFrameExtensions.cs
+++ b/ParquetSharp.DataFrame/DataFrameExtensions.cs
@@ -2,11 +2,11 @@ using System;
 using System.Linq;
 using Microsoft.Data.Analysis;
 
-namespace ParquetSharp.DataFrame
+namespace ParquetSharp
 {
     public static class DataFrameExtensions
     {
-        public static void ToParquet(this Microsoft.Data.Analysis.DataFrame dataFrame, string path)
+        public static void ToParquet(this DataFrame dataFrame, string path)
         {
             var propertiesBuilder = new WriterPropertiesBuilder();
             using var writerProperties = propertiesBuilder.Build();

--- a/ParquetSharp.DataFrame/DataFrameExtensions.cs
+++ b/ParquetSharp.DataFrame/DataFrameExtensions.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Linq;
+using Microsoft.Data.Analysis;
+
+namespace ParquetSharp.DataFrame
+{
+    public static class DataFrameExtensions
+    {
+        public static void ToParquet(this Microsoft.Data.Analysis.DataFrame dataFrame, string path)
+        {
+            var propertiesBuilder = new WriterPropertiesBuilder();
+            using var writerProperties = propertiesBuilder.Build();
+            var schemaColumns = dataFrame.Columns.Select(GetSchemaColumn).ToArray();
+            using var fileWriter = new ParquetFileWriter(path, schemaColumns, writerProperties);
+
+            const int rowGroupSize = 1024 * 1024;
+            var numRows = dataFrame.Rows.Count;
+            var offset = 0L;
+
+            while (offset < numRows)
+            {
+                var batchSize = (int) Math.Min(numRows - offset, rowGroupSize);
+                using var rowGroupWriter = fileWriter.AppendRowGroup();
+                foreach (var dataFrameColumn in dataFrame.Columns)
+                {
+                    using var columnWriter = rowGroupWriter.NextColumn();
+                    using var logicalWriter = columnWriter.LogicalWriter();
+                    logicalWriter.Apply(new DataFrameWriter(dataFrameColumn, offset, batchSize));
+                }
+                offset += batchSize;
+            }
+
+            fileWriter.Close();
+        }
+
+        private static Column GetSchemaColumn(DataFrameColumn column)
+        {
+            var dataType = column.DataType;
+            var nullable = column.NullCount > 0;
+            LogicalType logicalTypeOverride = null;
+            if (dataType == typeof(decimal))
+            {
+                // TODO: Work out how best to set precision and scale. May need to make this configurable?
+                // Parquet stores decimal as int value * 10^(-scale), and precision is number of digits of unscaled value
+                logicalTypeOverride = LogicalType.Decimal(29, 3);
+            }
+            if (nullable && dataType.IsValueType)
+            {
+                dataType = typeof(Nullable<>).MakeGenericType(dataType);
+            }
+            return new Column(dataType, column.Name, logicalTypeOverride);
+        }
+    }
+}

--- a/ParquetSharp.DataFrame/DataFrameSetter.cs
+++ b/ParquetSharp.DataFrame/DataFrameSetter.cs
@@ -8,6 +8,11 @@ namespace ParquetSharp
     /// </summary>
     internal sealed class DataFrameSetter : ILogicalColumnReaderVisitor<bool>
     {
+        /// <summary>
+        /// Create a DataFrameSetter
+        /// </summary>
+        /// <param name="dataFrameColumn">The column to read data into</param>
+        /// <param name="offset">Position to begin inserting data at</param>
         public DataFrameSetter(DataFrameColumn dataFrameColumn, long offset)
         {
             _dataFrameColumn = dataFrameColumn;

--- a/ParquetSharp.DataFrame/DataFrameSetter.cs
+++ b/ParquetSharp.DataFrame/DataFrameSetter.cs
@@ -23,40 +23,16 @@ namespace ParquetSharp
         {
             var buffer = new TElement[columnReader.BufferLength];
             long offset = 0;
-            var converter = GetConverter<TElement>();
             while (columnReader.HasNext)
             {
                 var read = columnReader.ReadBatch((Span<TElement>) buffer);
-                if (converter == null)
+                for (var i = 0; i != read; ++i)
                 {
-                    for (var i = 0; i != read; ++i)
-                    {
-                        _dataFrameColumn[_offset + offset + i] = buffer[i];
-                    }
-                }
-                else
-                {
-                    for (var i = 0; i != read; ++i)
-                    {
-                        _dataFrameColumn[_offset + offset + i] = converter(buffer[i]);
-                    }
+                    _dataFrameColumn[_offset + offset + i] = buffer[i];
                 }
                 offset += read;
             }
             return true;
-        }
-
-        private static Func<TElement, object?>? GetConverter<TElement>()
-        {
-            if (typeof(TElement) == typeof(Date))
-            {
-                return el => ((Date) (object) el!).Days;
-            }
-            if (typeof(TElement) == typeof(Date?))
-            {
-                return el => ((Date?) (object?) el)?.Days ?? null;
-            }
-            return null;
         }
 
         private readonly DataFrameColumn _dataFrameColumn;

--- a/ParquetSharp.DataFrame/DataFrameSetter.cs
+++ b/ParquetSharp.DataFrame/DataFrameSetter.cs
@@ -16,12 +16,12 @@ namespace ParquetSharp.DataFrame
 
         public bool OnLogicalColumnReader<TElement>(LogicalColumnReader<TElement> columnReader)
         {
-            TElement[] buffer = new TElement[columnReader.BufferLength];
+            var buffer = new TElement[columnReader.BufferLength];
             long offset = 0;
             while (columnReader.HasNext)
             {
-                int read = columnReader.ReadBatch((Span<TElement>) buffer);
-                for (int i = 0; i != read; ++i)
+                var read = columnReader.ReadBatch((Span<TElement>) buffer);
+                for (var i = 0; i != read; ++i)
                 {
                     _dataFrameColumn[_offset + offset + i] = buffer[i];
                 }

--- a/ParquetSharp.DataFrame/DataFrameSetter.cs
+++ b/ParquetSharp.DataFrame/DataFrameSetter.cs
@@ -1,0 +1,36 @@
+using System;
+using Microsoft.Data.Analysis;
+
+namespace ParquetSharp.DataFrame
+{
+    /// <summary>
+    /// LogicalColumnReaderVisitor that sets values in a DataFrameColumn
+    /// </summary>
+    internal sealed class DataFrameSetter : ILogicalColumnReaderVisitor<bool>
+    {
+        public DataFrameSetter(DataFrameColumn dataFrameColumn, long offset)
+        {
+            _dataFrameColumn = dataFrameColumn;
+            _offset = offset;
+        }
+
+        public bool OnLogicalColumnReader<TElement>(LogicalColumnReader<TElement> columnReader)
+        {
+            TElement[] buffer = new TElement[columnReader.BufferLength];
+            long offset = 0;
+            while (columnReader.HasNext)
+            {
+                int read = columnReader.ReadBatch((Span<TElement>) buffer);
+                for (int i = 0; i != read; ++i)
+                {
+                    _dataFrameColumn[_offset + offset + i] = buffer[i];
+                }
+                offset += read;
+            }
+            return true;
+        }
+
+        private readonly DataFrameColumn _dataFrameColumn;
+        private readonly long _offset;
+    }
+}

--- a/ParquetSharp.DataFrame/DataFrameSetter.cs
+++ b/ParquetSharp.DataFrame/DataFrameSetter.cs
@@ -25,13 +25,15 @@ namespace ParquetSharp
             long offset = 0;
             while (columnReader.HasNext)
             {
-                var read = columnReader.ReadBatch((Span<TElement>) buffer);
+                var read = columnReader.ReadBatch((Span<TElement>)buffer);
                 for (var i = 0; i != read; ++i)
                 {
                     _dataFrameColumn[_offset + offset + i] = buffer[i];
                 }
+
                 offset += read;
             }
+
             return true;
         }
 

--- a/ParquetSharp.DataFrame/DataFrameSetter.cs
+++ b/ParquetSharp.DataFrame/DataFrameSetter.cs
@@ -1,7 +1,7 @@
 using System;
 using Microsoft.Data.Analysis;
 
-namespace ParquetSharp.DataFrame
+namespace ParquetSharp
 {
     /// <summary>
     /// LogicalColumnReaderVisitor that sets values in a DataFrameColumn

--- a/ParquetSharp.DataFrame/DataFrameSetter.cs
+++ b/ParquetSharp.DataFrame/DataFrameSetter.cs
@@ -6,7 +6,7 @@ namespace ParquetSharp
     /// <summary>
     /// LogicalColumnReaderVisitor that sets values in a DataFrameColumn
     /// </summary>
-    internal sealed class DataFrameSetter : ILogicalColumnReaderVisitor<bool>
+    internal sealed class DataFrameSetter : ILogicalColumnReaderVisitor<Unit>
     {
         /// <summary>
         /// Create a DataFrameSetter
@@ -19,7 +19,7 @@ namespace ParquetSharp
             _offset = offset;
         }
 
-        public bool OnLogicalColumnReader<TElement>(LogicalColumnReader<TElement> columnReader)
+        public Unit OnLogicalColumnReader<TElement>(LogicalColumnReader<TElement> columnReader)
         {
             var buffer = new TElement[columnReader.BufferLength];
             long offset = 0;
@@ -34,7 +34,7 @@ namespace ParquetSharp
                 offset += read;
             }
 
-            return true;
+            return Unit.Instance;
         }
 
         private readonly DataFrameColumn _dataFrameColumn;

--- a/ParquetSharp.DataFrame/DataFrameWriter.cs
+++ b/ParquetSharp.DataFrame/DataFrameWriter.cs
@@ -25,8 +25,9 @@ namespace ParquetSharp
             var values = new TValue[_batchSize];
             for (var i = 0; i < _batchSize; ++i)
             {
-                values[i] = (TValue) _dataFrameColumn[_offset + i];
+                values[i] = (TValue)_dataFrameColumn[_offset + i];
             }
+
             columnWriter.WriteBatch(values);
             return true;
         }

--- a/ParquetSharp.DataFrame/DataFrameWriter.cs
+++ b/ParquetSharp.DataFrame/DataFrameWriter.cs
@@ -2,8 +2,17 @@ using Microsoft.Data.Analysis;
 
 namespace ParquetSharp
 {
+    /// <summary>
+    /// LogicalColumnWriterVisitor that writes data from a DataFrame column
+    /// </summary>
     public class DataFrameWriter : ILogicalColumnWriterVisitor<bool>
     {
+        /// <summary>
+        /// Create a DataFrameWriter
+        /// </summary>
+        /// <param name="dataFrameColumn">The column to read data from</param>
+        /// <param name="offset">The initial position to begin reading from</param>
+        /// <param name="batchSize">The number of values to write</param>
         public DataFrameWriter(DataFrameColumn dataFrameColumn, long offset, int batchSize)
         {
             _dataFrameColumn = dataFrameColumn;

--- a/ParquetSharp.DataFrame/DataFrameWriter.cs
+++ b/ParquetSharp.DataFrame/DataFrameWriter.cs
@@ -1,6 +1,6 @@
 using Microsoft.Data.Analysis;
 
-namespace ParquetSharp.DataFrame
+namespace ParquetSharp
 {
     public class DataFrameWriter : ILogicalColumnWriterVisitor<bool>
     {

--- a/ParquetSharp.DataFrame/DataFrameWriter.cs
+++ b/ParquetSharp.DataFrame/DataFrameWriter.cs
@@ -5,7 +5,7 @@ namespace ParquetSharp
     /// <summary>
     /// LogicalColumnWriterVisitor that writes data from a DataFrame column
     /// </summary>
-    public class DataFrameWriter : ILogicalColumnWriterVisitor<bool>
+    internal sealed class DataFrameWriter : ILogicalColumnWriterVisitor<Unit>
     {
         /// <summary>
         /// Create a DataFrameWriter
@@ -20,7 +20,7 @@ namespace ParquetSharp
             _batchSize = batchSize;
         }
 
-        public bool OnLogicalColumnWriter<TValue>(LogicalColumnWriter<TValue> columnWriter)
+        public Unit OnLogicalColumnWriter<TValue>(LogicalColumnWriter<TValue> columnWriter)
         {
             var values = new TValue[_batchSize];
             for (var i = 0; i < _batchSize; ++i)
@@ -29,7 +29,7 @@ namespace ParquetSharp
             }
 
             columnWriter.WriteBatch(values);
-            return true;
+            return Unit.Instance;
         }
 
         private readonly DataFrameColumn _dataFrameColumn;

--- a/ParquetSharp.DataFrame/DataFrameWriter.cs
+++ b/ParquetSharp.DataFrame/DataFrameWriter.cs
@@ -1,0 +1,29 @@
+using Microsoft.Data.Analysis;
+
+namespace ParquetSharp.DataFrame
+{
+    public class DataFrameWriter : ILogicalColumnWriterVisitor<bool>
+    {
+        public DataFrameWriter(DataFrameColumn dataFrameColumn, long offset, int batchSize)
+        {
+            _dataFrameColumn = dataFrameColumn;
+            _offset = offset;
+            _batchSize = batchSize;
+        }
+
+        public bool OnLogicalColumnWriter<TValue>(LogicalColumnWriter<TValue> columnWriter)
+        {
+            var values = new TValue[_batchSize];
+            for (var i = 0; i < _batchSize; ++i)
+            {
+                values[i] = (TValue) _dataFrameColumn[_offset + i];
+            }
+            columnWriter.WriteBatch(values);
+            return true;
+        }
+
+        private readonly DataFrameColumn _dataFrameColumn;
+        private readonly long _offset;
+        private readonly int _batchSize;
+    }
+}

--- a/ParquetSharp.DataFrame/ParquetFileReaderExtensions.cs
+++ b/ParquetSharp.DataFrame/ParquetFileReaderExtensions.cs
@@ -6,7 +6,7 @@ namespace ParquetSharp
 {
     public static class ParquetFileReaderExtensions
     {
-        public static DataFrame ToDataFrame(this ParquetFileReader fileReader, IReadOnlyList<string> columns = null)
+        public static DataFrame ToDataFrame(this ParquetFileReader fileReader, IReadOnlyList<string>? columns = null)
         {
             var numColumns = columns?.Count ?? fileReader.FileMetaData.NumColumns;
             var numRows = fileReader.FileMetaData.NumRows;

--- a/ParquetSharp.DataFrame/ParquetFileReaderExtensions.cs
+++ b/ParquetSharp.DataFrame/ParquetFileReaderExtensions.cs
@@ -1,0 +1,10 @@
+namespace ParquetSharp.DataFrame
+{
+    public static class ParquetFileReaderExtensions
+    {
+        public static Microsoft.Data.Analysis.DataFrame ToDataFrame(this ParquetFileReader fileReader)
+        {
+            return new Microsoft.Data.Analysis.DataFrame();
+        }
+    }
+}

--- a/ParquetSharp.DataFrame/ParquetFileReaderExtensions.cs
+++ b/ParquetSharp.DataFrame/ParquetFileReaderExtensions.cs
@@ -12,64 +12,29 @@ namespace ParquetSharp.DataFrame
             var numRows = fileReader.FileMetaData.NumRows;
             var dataFrameColumns = new List<DataFrameColumn>(numColumns);
 
-            for (int colIdx = 0; colIdx < numColumns; ++colIdx)
-            {
-                var descriptor = fileReader.FileMetaData.Schema.Column(colIdx);
-                dataFrameColumns.Add(CreateColumn(descriptor, numRows));
-            }
-
             long offset = 0;
-            for (int rowGroupIdx = 0; rowGroupIdx < fileReader.FileMetaData.NumRowGroups; ++rowGroupIdx)
+            for (var rowGroupIdx = 0; rowGroupIdx < fileReader.FileMetaData.NumRowGroups; ++rowGroupIdx)
             {
                 using var rowGroupReader = fileReader.RowGroup(rowGroupIdx);
-                for (int colIdx = 0; colIdx < numColumns; ++colIdx)
+                for (var colIdx = 0; colIdx < numColumns; ++colIdx)
                 {
                     using var columnReader = rowGroupReader.Column(colIdx);
                     using var logicalReader = columnReader.LogicalReader();
+
+                    if (rowGroupIdx == 0)
+                    {
+                        // On first row group, create columns
+                        var columnCreator = new ColumnCreator(logicalReader.ColumnDescriptor.Name, numRows);
+                        dataFrameColumns.Add(logicalReader.Apply(columnCreator));
+                    }
+
+                    // Read column data
                     logicalReader.Apply(new DataFrameSetter(dataFrameColumns[colIdx], offset));
                 }
                 offset += rowGroupReader.MetaData.NumRows;
             }
 
             return new Microsoft.Data.Analysis.DataFrame(dataFrameColumns);
-        }
-
-        private static DataFrameColumn CreateColumn(ColumnDescriptor descriptor, long numRows)
-        {
-            switch (descriptor.LogicalType)
-            {
-                case NoneLogicalType:
-                case IntLogicalType:
-                {
-                    switch (descriptor.PhysicalType)
-                    {
-                        case PhysicalType.Int32:
-                            return new PrimitiveDataFrameColumn<int>(descriptor.Name, numRows);
-                        case PhysicalType.Int64:
-                            return new PrimitiveDataFrameColumn<long>(descriptor.Name, numRows);
-                        case PhysicalType.Float:
-                            return new PrimitiveDataFrameColumn<float>(descriptor.Name, numRows);
-                        case PhysicalType.Double:
-                            return new PrimitiveDataFrameColumn<double>(descriptor.Name, numRows);
-                        case PhysicalType.Boolean:
-                            return new BooleanDataFrameColumn(descriptor.Name, numRows);
-                        default:
-                            throw new NotImplementedException($"Unsupported physical type: {descriptor.PhysicalType}");
-                    }
-                }
-                case StringLogicalType:
-                {
-                    return new StringDataFrameColumn(descriptor.Name, numRows);
-                }
-                case TimestampLogicalType:
-                {
-                    return new PrimitiveDataFrameColumn<DateTime>(descriptor.Name, numRows);
-                }
-                default:
-                {
-                    throw new NotImplementedException($"Unsupported column logical type: {descriptor.LogicalType.Type}");
-                }
-            }
         }
     }
 }

--- a/ParquetSharp.DataFrame/ParquetFileReaderExtensions.cs
+++ b/ParquetSharp.DataFrame/ParquetFileReaderExtensions.cs
@@ -6,7 +6,28 @@ namespace ParquetSharp
 {
     public static class ParquetFileReaderExtensions
     {
-        public static DataFrame ToDataFrame(this ParquetFileReader fileReader, IReadOnlyList<string>? columns = null)
+        /// <summary>
+        /// Read all data from a parquet file into a DataFrame
+        /// </summary>
+        /// <param name="fileReader">Reader for the ParquetFile to read</param>
+        /// <returns>Data from the Parquet file as a DataFrame</returns>
+        public static DataFrame ToDataFrame(this ParquetFileReader fileReader)
+        {
+            return ToDataFrameImpl(fileReader, null);
+        }
+
+        /// <summary>
+        /// Read specific columns from a parquet file into a DataFrame
+        /// </summary>
+        /// <param name="fileReader">Reader for the ParquetFile to read</param>
+        /// <param name="columns">List of columns to read</param>
+        /// <returns>Column Data from the Parquet file as a DataFrame</returns>
+        public static DataFrame ToDataFrame(this ParquetFileReader fileReader, IReadOnlyList<string> columns)
+        {
+            return ToDataFrameImpl(fileReader, columns);
+        }
+
+        private static DataFrame ToDataFrameImpl(this ParquetFileReader fileReader, IReadOnlyList<string>? columns = null)
         {
             var numColumns = columns?.Count ?? fileReader.FileMetaData.NumColumns;
             var numRows = fileReader.FileMetaData.NumRows;

--- a/ParquetSharp.DataFrame/ParquetFileReaderExtensions.cs
+++ b/ParquetSharp.DataFrame/ParquetFileReaderExtensions.cs
@@ -1,11 +1,11 @@
 using System.Collections.Generic;
 using Microsoft.Data.Analysis;
 
-namespace ParquetSharp.DataFrame
+namespace ParquetSharp
 {
     public static class ParquetFileReaderExtensions
     {
-        public static Microsoft.Data.Analysis.DataFrame ToDataFrame(this ParquetFileReader fileReader)
+        public static DataFrame ToDataFrame(this ParquetFileReader fileReader)
         {
             var numColumns = fileReader.FileMetaData.NumColumns;
             var numRows = fileReader.FileMetaData.NumRows;
@@ -33,7 +33,7 @@ namespace ParquetSharp.DataFrame
                 offset += rowGroupReader.MetaData.NumRows;
             }
 
-            return new Microsoft.Data.Analysis.DataFrame(dataFrameColumns);
+            return new DataFrame(dataFrameColumns);
         }
     }
 }

--- a/ParquetSharp.DataFrame/ParquetFileReaderExtensions.cs
+++ b/ParquetSharp.DataFrame/ParquetFileReaderExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Microsoft.Data.Analysis;
 

--- a/ParquetSharp.DataFrame/ParquetFileReaderExtensions.cs
+++ b/ParquetSharp.DataFrame/ParquetFileReaderExtensions.cs
@@ -46,7 +46,7 @@ namespace ParquetSharp
                 for (var colIdx = 0; colIdx < numColumns; ++colIdx)
                 {
                     using var columnReader = rowGroupReader.Column(columnIndexMap[colIdx]);
-                    using var logicalReader = GetLogicalReader(columnReader);
+                    using var logicalReader = columnReader.LogicalReader();
 
                     if (rowGroupIdx == 0)
                     {
@@ -62,20 +62,6 @@ namespace ParquetSharp
             }
 
             return new DataFrame(dataFrameColumns);
-        }
-
-        private static LogicalColumnReader GetLogicalReader(ColumnReader columnReader)
-        {
-            // Override the logical type to use when reading dates, and just read these
-            // as the underlying physical integer type, as there isn't a directly corresponding DataFrame column type
-            // that can handle dates and times.
-            if (columnReader.ColumnDescriptor.LogicalType is DateLogicalType)
-            {
-                return columnReader.ColumnDescriptor.MaxDefinitionLevel == 0
-                    ? columnReader.LogicalReaderOverride<int>()
-                    : columnReader.LogicalReaderOverride<int?>();
-            }
-            return columnReader.LogicalReader();
         }
 
         private static int FindColumnIndex(string column, SchemaDescriptor schema)

--- a/ParquetSharp.DataFrame/ParquetFileReaderExtensions.cs
+++ b/ParquetSharp.DataFrame/ParquetFileReaderExtensions.cs
@@ -1,10 +1,62 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Data.Analysis;
+
 namespace ParquetSharp.DataFrame
 {
     public static class ParquetFileReaderExtensions
     {
         public static Microsoft.Data.Analysis.DataFrame ToDataFrame(this ParquetFileReader fileReader)
         {
-            return new Microsoft.Data.Analysis.DataFrame();
+            var numColumns = fileReader.FileMetaData.NumColumns;
+            var numRows = fileReader.FileMetaData.NumRows;
+            var columns = new List<DataFrameColumn>(numColumns);
+
+            for (int i = 0; i < numColumns; ++i)
+            {
+                var descriptor = fileReader.FileMetaData.Schema.Column(i);
+                columns.Add(CreateColumn(descriptor, numRows));
+            }
+
+            return new Microsoft.Data.Analysis.DataFrame(columns);
+        }
+
+        private static DataFrameColumn CreateColumn(ColumnDescriptor descriptor, long numRows)
+        {
+            switch (descriptor.LogicalType)
+            {
+                case NoneLogicalType:
+                case IntLogicalType:
+                {
+                    switch (descriptor.PhysicalType)
+                    {
+                        case PhysicalType.Int32:
+                            return new PrimitiveDataFrameColumn<int>(descriptor.Name, numRows);
+                        case PhysicalType.Int64:
+                            return new PrimitiveDataFrameColumn<long>(descriptor.Name, numRows);
+                        case PhysicalType.Float:
+                            return new PrimitiveDataFrameColumn<float>(descriptor.Name, numRows);
+                        case PhysicalType.Double:
+                            return new PrimitiveDataFrameColumn<double>(descriptor.Name, numRows);
+                        case PhysicalType.Boolean:
+                            return new BooleanDataFrameColumn(descriptor.Name, numRows);
+                        default:
+                            throw new NotImplementedException($"Unsupported physical type: {descriptor.PhysicalType}");
+                    }
+                }
+                case StringLogicalType:
+                {
+                    return new StringDataFrameColumn(descriptor.Name, numRows);
+                }
+                case TimestampLogicalType:
+                {
+                    return new PrimitiveDataFrameColumn<DateTime>(descriptor.Name, numRows);
+                }
+                default:
+                {
+                    throw new NotImplementedException($"Unsupported column logical type: {descriptor.LogicalType.Type}");
+                }
+            }
         }
     }
 }

--- a/ParquetSharp.DataFrame/ParquetFileReaderExtensions.cs
+++ b/ParquetSharp.DataFrame/ParquetFileReaderExtensions.cs
@@ -58,6 +58,7 @@ namespace ParquetSharp
                     // Read column data
                     logicalReader.Apply(new DataFrameSetter(dataFrameColumns[colIdx], offset));
                 }
+
                 offset += rowGroupReader.MetaData.NumRows;
             }
 
@@ -71,6 +72,7 @@ namespace ParquetSharp
             {
                 throw new ArgumentException($"Invalid column path '{column}'");
             }
+
             return index;
         }
     }

--- a/ParquetSharp.DataFrame/ParquetSharp.DataFrame.csproj
+++ b/ParquetSharp.DataFrame/ParquetSharp.DataFrame.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace>ParquetSharp</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ParquetSharp.DataFrame/ParquetSharp.DataFrame.csproj
+++ b/ParquetSharp.DataFrame/ParquetSharp.DataFrame.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>ParquetSharp</RootNamespace>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ParquetSharp.DataFrame/ParquetSharp.DataFrame.csproj
+++ b/ParquetSharp.DataFrame/ParquetSharp.DataFrame.csproj
@@ -1,9 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net471;netstandard2.1</TargetFrameworks>
+    <LangVersion>9.0</LangVersion>
+    <AssemblyName>ParquetSharp.DataFrame</AssemblyName>
     <RootNamespace>ParquetSharp</RootNamespace>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Version>0.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ParquetSharp.DataFrame/ParquetSharp.DataFrame.csproj
+++ b/ParquetSharp.DataFrame/ParquetSharp.DataFrame.csproj
@@ -6,9 +6,25 @@
     <AssemblyName>ParquetSharp.DataFrame</AssemblyName>
     <RootNamespace>ParquetSharp</RootNamespace>
     <Nullable>enable</Nullable>
+    <PlatformTarget Condition="'$(TargetFramework)'=='net471'">x64</PlatformTarget>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Version>0.1.0</Version>
+    <Company>G-Research</Company>
+    <Authors>G-Research</Authors>
+    <Product>ParquetSharp.DataFrame</Product>
+    <Description>ParquetSharp.DataFrame is a .NET library for reading and writing Apache Parquet files into/from .NET DataFrames, using ParquetSharp.</Description>
+    <Copyright>Copyright G-Research 2021</Copyright>
+    <PackageProjectUrl>https://github.com/G-Research/ParquetSharp.DataFrame</PackageProjectUrl>
+    <PackageTags>dataframe apache parquet gresearch g-research .net c#</PackageTags>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
+
+  <ItemGroup Label="Additional nuget files">
+    <None Include="../LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Analysis" Version="0.19.0" />

--- a/ParquetSharp.DataFrame/ParquetSharp.DataFrame.csproj
+++ b/ParquetSharp.DataFrame/ParquetSharp.DataFrame.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Analysis" Version="0.19.0" />
+    <PackageReference Include="ParquetSharp" Version="4.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/ParquetSharp.DataFrame/Unit.cs
+++ b/ParquetSharp.DataFrame/Unit.cs
@@ -1,0 +1,11 @@
+namespace ParquetSharp
+{
+    internal sealed class Unit
+    {
+        public static readonly Unit Instance = new Unit();
+
+        private Unit()
+        {
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -56,11 +56,13 @@ using (var propertiesBuilder = new WriterPropertiesBuilder())
 The logical type to use when writing a column can optionally be overridden.
 This is required when writing decimal columns, as you must specify the precision and scale to be used
 (see the [Parquet documentation](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#decimal) for more details).
-For example:
+This also allows writing an integer column as a Parquet date or time.
 
 ```C#
 dataFrame.ToParquet(parquet_file_path, logicalTypeOverrides: new Dictionary<string, LogicalType>
 {
-    {"decimal_col_name", LogicalType.Decimal(precision: 29, scale: 3)},
+    {"decimal_column", LogicalType.Decimal(precision: 29, scale: 3)},
+    {"date_column", LogicalType.Date()},
+    {"time_column", LogicalType.Time(isAdjustedToUtc: true, TimeUnit.Millis)},
 });
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,66 @@
 # ParquetSharp.DataFrame
-ParquetSharp.DataFrame is a .NET library for reading and writing Apache Parquet files into/from .NET DataFrames, using ParquetSharp
+
+ParquetSharp.DataFrame is a .NET library for reading and writing Apache Parquet files into/from .NET [DataFrames][1], using [ParquetSharp][2].
+
+[1]: https://docs.microsoft.com/en-us/dotnet/api/microsoft.data.analysis.dataframe
+[2]: https://github.com/G-Research/ParquetSharp
+
+## Reading Parquet files
+
+Parquet data is read into a `DataFrame` using `ToDataFrame` extension methods on `ParquetFileReader`,
+for example:
+
+```C#
+using ParquetSharp;
+
+using (var parquetReader = new ParquetFileReader(parquet_file_path))
+{
+    var dataFrame = parquetReader.ToDataFrame();
+    parquetReader.Close();
+}
+
+```
+
+An overload is provided that allows you to read specific columns from the Parquet file:
+
+```C#
+var dataFrame = parquetReader.ToDataFrame(columns: new [] {"col_1", "col_2"});
+
+```
+
+## Writing Parquet files
+
+Parquet files are written using the `ToParquet` extension method on `DataFrame`:
+
+```C#
+using ParquetSharp;
+using Microsoft.Data.Analysis;
+
+var dataFrame = new DataFrame(columns);
+dataFrame.ToParquet(parquet_file_path);
+```
+
+Parquet writing options can be overridden by providing an instance of `WriterProperties`:
+
+```C#
+using (var propertiesBuilder = new WriterPropertiesBuilder())
+{
+    propertiesBuilder.Compression(Compression.Snappy);
+    using (var properties = propertiesBuilder.Build())
+    {
+        dataFrame.ToParquet(parquet_file_path, properties);
+    }
+}
+```
+
+The logical type to use when writing a column can optionally be overridden.
+This is required when writing decimal columns, as you must specify the precision and scale to be used
+(see the [Parquet documentation](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#decimal) for more details).
+For example:
+
+```C#
+dataFrame.ToParquet(parquet_file_path, logicalTypeOverrides: new Dictionary<string, LogicalType>
+{
+    {"decimal_col_name", LogicalType.Decimal(precision: 29, scale: 3)},
+});
+```

--- a/README.md
+++ b/README.md
@@ -69,3 +69,23 @@ dataFrame.ToParquet(parquet_file_path, logicalTypeOverrides: new Dictionary<stri
     {"time_column", LogicalType.Time(isAdjustedToUtc: true, TimeUnit.Millis)},
 });
 ```
+
+## Contributing
+
+We welcome new contributors! We will happily receive PRs for bug fixes or small changes.
+If you're contemplating something larger please get in touch first by opening a GitHub Issue describing the problem and how you propose to solve it.
+
+## License
+
+Copyright 2021 G-Research
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use these files except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -18,14 +18,17 @@ using (var parquetReader = new ParquetFileReader(parquet_file_path))
     var dataFrame = parquetReader.ToDataFrame();
     parquetReader.Close();
 }
-
 ```
 
-An overload is provided that allows you to read specific columns from the Parquet file:
+Overloads are provided that allow you to read specific columns from the Parquet file,
+and/or a subset of row groups:
 
 ```C#
 var dataFrame = parquetReader.ToDataFrame(columns: new [] {"col_1", "col_2"});
+```
 
+```C#
+var dataFrame = parquetReader.ToDataFrame(rowGroupIndices: new [] {0, 1});
 ```
 
 ## Writing Parquet files


### PR DESCRIPTION
This adds the initial code for reading and writing Parquet to/from a DataFrame, as well as CI configuration which is mostly adapted from ParquetSharp.

One thing I wasn't sure about is whether to keep these extension methods in the ParquetSharp namespace or move them to a separate namespace. Using `ParquetSharp.DataFrame` as the namespace isn't ideal as then the namespace will clash with the `DataFrame` class name. Possibly `ParquetSharp.DataFrameExtensions`? At the moment though I'm leaning towards leaving things as is and using the `ParquetSharp` namespace. Given this is a project under the `ParquetSharp` umbrella and the public API surface is small, I don't think name clashes with core `ParquetSharp` are a big concern, and the practice of smaller NuGet packages that share a common namespace is pretty common across Microsoft projects (eg. the various Microsoft.ML packages for example).