### PR TITLE
Create "All required checks succeeded" check run when "All required checks done" CI job is actually successful

### DIFF
--- a/.github/workflows/check-required.yml
+++ b/.github/workflows/check-required.yml
@@ -1,0 +1,58 @@
+name: Check required jobs
+
+# This workflow is triggered when a workflow run for the CI is completed.
+# It checks if the "All required checks done" job was actually successful
+# (and not just skipped) and creates a check run if that is the case. The
+# check run can be used to protect the main branch from being merged if the
+# CI is not passing.
+
+on:
+  workflow_run:
+    types: [completed]
+    workflows: [CI]
+
+permissions:
+  actions: read
+  checks: write
+
+jobs:
+  required-jobs:
+    name: Check required jobs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            // list jobs for worklow run attempt
+            const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRunAttempt({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              run_id: context.payload.workflow_run.id,
+              attempt_number: context.payload.workflow_run.run_attempt,
+            });
+            // check if required job was successful
+            var success = false;
+            core.info(`Checking jobs for workflow run ${context.payload.workflow_run.html_url}`);
+            jobs.forEach(job => {
+              var mark = '-'
+              if (job.name === 'All required checks done' && job.conclusion === 'success') {
+                success = true;
+                mark = '✅';
+              }
+              core.info(`${mark} ${job.name}: ${job.conclusion}`);
+            });
+            // create check run if job was successful
+            if (success) {
+              await github.rest.checks.create({
+                owner: context.payload.repository.owner.login,
+                repo: context.payload.repository.name,
+                name: 'All required checks succeeded',
+                head_sha: context.payload.workflow_run.head_sha,
+                status: 'completed',
+                conclusion: 'success',
+                output: {
+                  title: 'All required checks succeeded',
+                  summary: `See [workflow run](${context.payload.workflow_run.html_url}) for details.`,
+                },
+              });
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
 
   # Build the nuget package and upload it as an artifact.
   build-nuget:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     name: Build NuGet package
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
       run: dotnet test ParquetSharp.DataFrame.Test --configuration=Release --framework ${{ matrix.dotnet }}
 
   # Virtual job that can be configured as a required check before a PR can be merged.
+  # As GitHub considers a check as successful if it is skipped, we need to check its status in
+  # another workflow (check-required.yml) and create a check there.
   all-required-checks-done:
     name: All required checks done
     needs:
@@ -115,21 +117,7 @@ jobs:
       - test-nuget
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
-        with:
-          script: |
-            github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'All required checks succeeded',
-              head_sha: context.sha,
-              status: 'completed',
-              conclusion: 'success',
-              output: {
-                title: 'All required checks done',
-                summary: 'All required checks succeeded'
-              }
-            });
+      - run: echo "All required checks done"
 
   # Create a GitHub release and publish the NuGet packages to nuget.org when a tag is pushed.
   publish-release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,12 +126,21 @@ jobs:
   # Virtual job that can be configured as a required check before a PR can be merged.
   all-required-checks-done:
     name: All required checks done
+    if: ${{ always() }}
     needs:
       - check-format
       - test-nuget
     runs-on: ubuntu-latest
     steps:
-      - run: echo "All required checks done"
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const results = ${{ toJSON(needs.*.result) }};
+            if (results.every(res => res === 'success')) {
+              core.info('All required checks succeeded');
+            } else {
+              core.setFailed('Some required checks failed');
+            }
 
   # Create a GitHub release and publish the NuGet packages to nuget.org when a tag is pushed.
   publish-release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
   # Virtual job that can be configured as a required check before a PR can be merged.
   all-required-checks-done:
     name: All required checks done
-    if: ${{ always() }}
+    if: ${{ always() && (github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id) }}
     needs:
       - check-format
       - test-nuget

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,6 @@ jobs:
   # Virtual job that can be configured as a required check before a PR can be merged.
   all-required-checks-done:
     name: All required checks done
-    if: ${{ always() && (github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id) }}
     needs:
       - check-format
       - test-nuget
@@ -119,12 +118,18 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            const results = ${{ toJSON(needs.*.result) }};
-            if (results.every(res => res === 'success')) {
-              core.info('All required checks succeeded');
-            } else {
-              core.setFailed('Some required checks failed');
-            }
+            github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'All required checks succeeded',
+              head_sha: context.sha,
+              status: 'completed',
+              conclusion: 'success',
+              output: {
+                title: 'All required checks done',
+                summary: 'All required checks succeeded'
+              }
+            });
 
   # Create a GitHub release and publish the NuGet packages to nuget.org when a tag is pushed.
   publish-release:


### PR DESCRIPTION
The "All required checks done" CI job has been designed to be a required check, but GitHub considers it successful when it's skipped, and it gets skipped when some of the jobs it depends on fail.

This PR fixes that by ~always running the job and checking the results of all the jobs it depends on~ checking in a separate workflow whether the job conclusion is `success` and creates a new check run "All required checks **succeeded**" when it's the case. When it's not the case, the check run is not created and PRs will thus not be mergeable.

Example runs:
- [successful run](https://github.com/jgiannuzzi/fasttrackml/actions/runs/5858130823) — the [check run](https://github.com/jgiannuzzi/fasttrackml/runs/15881484894) is created by this [workflow run](https://github.com/jgiannuzzi/fasttrackml/actions/runs/5858187124/job/15881638649#step:2:47)
- [skipped run](https://github.com/jgiannuzzi/fasttrackml/actions/runs/5858128921) — the check run was _not_ created by this [workflow run](https://github.com/jgiannuzzi/fasttrackml/actions/runs/5858130484/job/15881468808#step:2:47)
- [failed run](https://github.com/jgiannuzzi/fasttrackml/actions/runs/5858124644) — the check run was _not_ created by this [workflow run](https://github.com/jgiannuzzi/fasttrackml/actions/runs/5858128916/job/15881462725#step:2:47)

I changed the workflow output slightly to show a ❌ when "All required checks done" is not successful, but this is not reflected in the above examples.