### PR TITLE
enable linter, note: build fails

### DIFF
--- a/ParquetSharp.DataFrame/ParquetSharp.DataFrame.csproj
+++ b/ParquetSharp.DataFrame/ParquetSharp.DataFrame.csproj
@@ -17,6 +17,7 @@
     <PackageProjectUrl>https://github.com/G-Research/ParquetSharp.DataFrame</PackageProjectUrl>
     <PackageTags>dataframe apache parquet gresearch g-research .net c#</PackageTags>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <CodeAnalysisRuleSet>stylecop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup Label="Additional nuget files">
@@ -29,6 +30,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Analysis" Version="0.20.1" />
     <PackageReference Include="ParquetSharp" Version="4.0.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/ParquetSharp.DataFrame/stylecop.json
+++ b/ParquetSharp.DataFrame/stylecop.json
@@ -1,0 +1,8 @@
+{
+  "settings": {
+    "documentationRules": {
+      "documentInterfaces": false,
+      "documentExposedElements": true
+    }
+  }
+}

--- a/ParquetSharp.DataFrame/stylecop.ruleset
+++ b/ParquetSharp.DataFrame/stylecop.ruleset
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="StyleCop Rules" Description="All StyleCop rules with warnings" ToolsVersion="15.0">
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="Warning" />
+    <!-- Repeat for each rule you want to configure -->
+  </Rules>
+</RuleSet>


### PR DESCRIPTION
The goal of this PR is to enable linting checks as part of the CI
Check will fail the build if rule sets are not met